### PR TITLE
Detects Kubernetes cluster DNS suffix correctly

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gnmic-operator
 description: A Kubernetes operator for deploying and managing gNMIc telemetry collectors at scale
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.3.1
+appVersion: "0.3.1"
 home: https://operator.gnmic.dev
 sources:
   - https://github.com/gnmic/operator

--- a/helm/templates/certificate.yaml
+++ b/helm/templates/certificate.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   dnsNames:
     - {{ include "gnmic-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
-    - {{ include "gnmic-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "gnmic-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   issuerRef:
     kind: {{ .Values.certManager.issuer.kind }}
     name: {{ include "gnmic-operator.issuerName" . }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,9 +8,13 @@ image:
   # Overrides the image tag whose default is the chart appVersion
   # tag: "0.0.1"
 
-imagePullSecrets: []
+imagePullSecrets: {}
 nameOverride: ""
 fullnameOverride: ""
+
+## @param clusterDomain Cluster domain
+##
+clusterDomain: cluster.local
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -711,8 +711,8 @@ func (r *ClusterReconciler) applyConfigToPods(ctx context.Context, cluster *gnmi
 		}
 		// build the URL for this pod
 		// statefulSet pods have predictable DNS names:
-		//  <statefulset-name>-<ordinal>.<service-name>.<namespace>.svc.cluster.local
-		podDNS := fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local", stsName, podIndex, stsName, cluster.Namespace)
+		//  <statefulset-name>-<ordinal>.<service-name>.<namespace>.svc.<cluster-domain>
+		podDNS := fmt.Sprintf("%s-%d.%s.%s.svc.%s", stsName, podIndex, stsName, cluster.Namespace, gnmic.ClusterDomain())
 		scheme := "http"
 		if cluster.Spec.API != nil && cluster.Spec.API.TLS != nil && cluster.Spec.API.TLS.IssuerRef != "" {
 			scheme = "https"
@@ -1349,13 +1349,13 @@ func (r *ClusterReconciler) reconcileCertificates(ctx context.Context, cluster *
 // buildCertificate creates a cert-manager Certificate spec for a pod
 func (r *ClusterReconciler) buildCertificate(cluster *gnmicv1alpha1.Cluster, certName, podName, stsName string) *certmanagerv1.Certificate {
 	// build DNS names for the certificate
-	// pod DNS: <pod-name>.<service-name>.<namespace>.svc.cluster.local
+	// pod DNS: <pod-name>.<service-name>.<namespace>.svc.<cluster-domain>
 	dnsNames := []string{
 		podName,
 		fmt.Sprintf("%s.%s", podName, stsName),
 		fmt.Sprintf("%s.%s.%s", podName, stsName, cluster.Namespace),
 		fmt.Sprintf("%s.%s.%s.svc", podName, stsName, cluster.Namespace),
-		fmt.Sprintf("%s.%s.%s.svc.cluster.local", podName, stsName, cluster.Namespace),
+		fmt.Sprintf("%s.%s.%s.svc.%s", podName, stsName, cluster.Namespace, gnmic.ClusterDomain()),
 	}
 
 	return &certmanagerv1.Certificate{
@@ -1538,7 +1538,7 @@ func (r *ClusterReconciler) buildTunnelCertificate(cluster *gnmicv1alpha1.Cluste
 		fmt.Sprintf("%s.%s", podName, stsName),
 		fmt.Sprintf("%s.%s.%s", podName, stsName, cluster.Namespace),
 		fmt.Sprintf("%s.%s.%s.svc", podName, stsName, cluster.Namespace),
-		fmt.Sprintf("%s.%s.%s.svc.cluster.local", podName, stsName, cluster.Namespace),
+		fmt.Sprintf("%s.%s.%s.svc.%s", podName, stsName, cluster.Namespace, gnmic.ClusterDomain()),
 	}
 
 	// also add the tunnel service DNS names if service is configured
@@ -1548,7 +1548,7 @@ func (r *ClusterReconciler) buildTunnelCertificate(cluster *gnmicv1alpha1.Cluste
 			tunnelServiceName,
 			fmt.Sprintf("%s.%s", tunnelServiceName, cluster.Namespace),
 			fmt.Sprintf("%s.%s.svc", tunnelServiceName, cluster.Namespace),
-			fmt.Sprintf("%s.%s.svc.cluster.local", tunnelServiceName, cluster.Namespace),
+			fmt.Sprintf("%s.%s.svc.%s", tunnelServiceName, cluster.Namespace, gnmic.ClusterDomain()),
 		)
 	}
 
@@ -2332,7 +2332,7 @@ func (r *ClusterReconciler) resolveOutputServiceAddresses(ctx context.Context, o
 		}
 
 		// use cluster DNS name for the service
-		host := fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace)
+		host := fmt.Sprintf("%s.%s.svc.%s", svc.Name, svc.Namespace, gnmic.ClusterDomain())
 		addr := gnmic.FormatServiceAddress(spec, host, port)
 		if spec.ServiceRef.URL != "" {
 			url := strings.TrimPrefix(spec.ServiceRef.URL, "/")
@@ -2372,7 +2372,7 @@ func (r *ClusterReconciler) resolveOutputServiceAddresses(ctx context.Context, o
 			}
 
 			// use cluster DNS name for the service
-			host := fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace)
+			host := fmt.Sprintf("%s.%s.svc.%s", svc.Name, svc.Namespace, gnmic.ClusterDomain())
 			addr := gnmic.FormatServiceAddress(spec, host, port)
 			if spec.ServiceSelector.URL != "" {
 				url := strings.TrimPrefix(spec.ServiceSelector.URL, "/")
@@ -2648,7 +2648,7 @@ func (r *ClusterReconciler) buildStatefulSet(cluster *gnmicv1alpha1.Cluster) (*a
 						VolumeAttributes: map[string]string{
 							"csi.cert-manager.io/issuer-name": cluster.Spec.API.TLS.IssuerRef,
 							"csi.cert-manager.io/issuer-kind": "Issuer",
-							"csi.cert-manager.io/dns-names":   "${POD_NAME}." + stsName + "." + cluster.Namespace + ".svc.cluster.local",
+							"csi.cert-manager.io/dns-names":   "${POD_NAME}." + stsName + "." + cluster.Namespace + ".svc." + gnmic.ClusterDomain(),
 							// "csi.cert-manager.io/renewBefore": "72h", // TODO: make configurable ?
 						},
 					},
@@ -2762,7 +2762,7 @@ func (r *ClusterReconciler) buildStatefulSet(cluster *gnmicv1alpha1.Cluster) (*a
 							VolumeAttributes: map[string]string{
 								"csi.cert-manager.io/issuer-name": cluster.Spec.GRPCTunnel.TLS.IssuerRef,
 								"csi.cert-manager.io/issuer-kind": "Issuer",
-								"csi.cert-manager.io/dns-names":   "${POD_NAME}." + stsName + "." + cluster.Namespace + ".svc.cluster.local",
+								"csi.cert-manager.io/dns-names":   "${POD_NAME}." + stsName + "." + cluster.Namespace + ".svc." + gnmic.ClusterDomain(),
 							},
 						},
 					},

--- a/internal/controller/targetstate_controller.go
+++ b/internal/controller/targetstate_controller.go
@@ -557,7 +557,7 @@ func (r *TargetStateReconciler) podBaseURL(cluster *gnmicv1alpha1.Cluster, stsNa
 		restPort = cluster.Spec.API.RestPort
 	}
 
-	podDNS := fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local", stsName, podIndex, stsName, cluster.Namespace)
+	podDNS := fmt.Sprintf("%s-%d.%s.%s.svc.%s", stsName, podIndex, stsName, cluster.Namespace, gnmic.ClusterDomain())
 	scheme := "http"
 	if cluster.Spec.API != nil && cluster.Spec.API.TLS != nil && cluster.Spec.API.TLS.IssuerRef != "" {
 		scheme = "https"

--- a/internal/gnmic/dns.go
+++ b/internal/gnmic/dns.go
@@ -1,0 +1,72 @@
+package gnmic
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+)
+
+const defaultClusterDomain = "cluster.local"
+
+// clusterDomain is resolved once at process start from /etc/resolv.conf's
+// search domains (falling back to defaultClusterDomain).
+//
+// The operator builds in-cluster FQDNs for gNMIc pods
+// (<pod>.<service>.<namespace>.svc.<cluster-domain>) to reach their REST
+// API (config-apply, SSE target-state streaming) and to build cert SANs.
+// These were previously hardcoded to "cluster.local", which breaks every
+// one of those lookups on any cluster configured with a different DNS
+// domain (kubelet --cluster-domain) -- confirmed as the root cause of
+// persistent "no such host" errors on a cluster using a custom domain.
+var clusterDomain = detectClusterDomain()
+
+// ClusterDomain returns the cluster's DNS domain (e.g. "cluster.local"),
+// used to build in-cluster FQDNs for gNMIc pods. Can be overridden with
+// the CLUSTER_DOMAIN environment variable for clusters where
+// auto-detection from /etc/resolv.conf isn't reliable.
+func ClusterDomain() string {
+	if v := os.Getenv("CLUSTER_DOMAIN"); v != "" {
+		return v
+	}
+	return clusterDomain
+}
+
+func detectClusterDomain() string {
+	f, err := os.Open("/etc/resolv.conf")
+	if err != nil {
+		return defaultClusterDomain
+	}
+	defer f.Close()
+	return parseClusterDomain(f)
+}
+
+// parseClusterDomain extracts the cluster domain from resolv.conf content
+// (split out from detectClusterDomain so the parsing logic is unit-testable
+// without depending on the host's actual /etc/resolv.conf).
+func parseClusterDomain(r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 || fields[0] != "search" {
+			continue
+		}
+		// Kubernetes orders search domains most-specific to least-specific, e.g.:
+		//   <namespace>.svc.<cluster-domain> svc.<cluster-domain> <cluster-domain>
+		// the "svc.<cluster-domain>" entry gives us the domain directly;
+		// fall back to the shortest entry if it's absent for some reason.
+		var shortest string
+		for _, d := range fields[1:] {
+			if strings.HasPrefix(d, "svc.") {
+				return strings.TrimPrefix(d, "svc.")
+			}
+			if shortest == "" || len(d) < len(shortest) {
+				shortest = d
+			}
+		}
+		if shortest != "" {
+			return shortest
+		}
+	}
+	return defaultClusterDomain
+}


### PR DESCRIPTION
1. Detects Kubernetes cluster DNS suffix correctly
2. Adds an ability to use custom domain suffix
3. Fixes #103 