### PR TITLE
Update CRDs, RBAC, and ServiceMonitor in Helm Chart & Add CI Check for Helm CRDs 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,13 +100,13 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Generate manifests
-        run: make manifests generate
+      - name: Generate manifests and sync Helm CRDs
+        run: make manifests generate helm-crds
 
       - name: Check for uncommitted changes
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "::error::Generated manifests are out of date. Please run 'make manifests generate' and commit the changes."
+            echo "::error::Generated manifests or Helm CRDs are out of date. Please run 'make manifests generate helm-crds' and commit the changes."
             git diff
             exit 1
           fi
@@ -126,6 +126,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-      
+
       - name: Run integration tests
         run: make run-integration-tests IMG=gnmic-operator:ci

--- a/helm/crds/operator.gnmic.dev_clusters.yaml
+++ b/helm/crds/operator.gnmic.dev_clusters.yaml
@@ -30,6 +30,9 @@ spec:
     - jsonPath: .status.targetsCount
       name: Targets
       type: integer
+    - jsonPath: .status.unassignedTargets
+      name: Unassigned
+      type: integer
     - jsonPath: .status.subscriptionsCount
       name: Subs
       type: integer
@@ -396,6 +399,15 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              targetDistribution:
+                description: The target distribution configuration
+                properties:
+                  podCapacity:
+                    description: |-
+                      The capacity per pod for distributing targets
+                      To be used in conjunction with Horizontal Pod Autoscaling (HPA) scaling.
+                    type: integer
+                type: object
             required:
             - image
             type: object
@@ -475,6 +487,9 @@ spec:
                 description: The number of ready replicas
                 format: int32
                 type: integer
+              selector:
+                description: The selector for the cluster statefulset
+                type: string
               subscriptionsCount:
                 description: The number of subscriptions referenced by the pipelines
                 format: int32
@@ -483,16 +498,28 @@ spec:
                 description: The number of targets referenced by the pipelines
                 format: int32
                 type: integer
+              unassignedTargets:
+                description: |-
+                  The number of targets that could not be assigned to any pod due to capacity limits.
+                  Non-zero when total targets exceed numPods × perPodCapacity.
+                format: int32
+                type: integer
             required:
             - inputsCount
             - outputsCount
             - pipelinesCount
             - readyReplicas
+            - selector
             - subscriptionsCount
             - targetsCount
+            - unassignedTargets
             type: object
         type: object
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.readyReplicas
       status: {}

--- a/helm/crds/operator.gnmic.dev_outputs.yaml
+++ b/helm/crds/operator.gnmic.dev_outputs.yaml
@@ -74,7 +74,7 @@ spec:
               serviceRef:
                 description: |-
                   ServiceRef references a Kubernetes Service to use as the output address.
-                  Supported for: nats, jetstream, kafka outputs.
+                  Supported for: nats, jetstream, kafka, remote_write, influxdb outputs.
                   The service address will be resolved and injected into the output config.
                 properties:
                   name:
@@ -89,13 +89,21 @@ spec:
                       Port is the name or number of the port to use.
                       If not specified, the first port of the service is used.
                     type: string
+                  url:
+                    description: |-
+                      URL is an optional path suffix appended after the resolved service address
+                      (scheme, host, and port). A leading slash on the value is optional; the
+                      operator joins the base and suffix with a single '/'. Use this for HTTP(S)
+                      outputs such as prometheus_write (for example api/v1/write or api/v1/push)
+                      or influxdb instead of putting the full URL in config.
+                    type: string
                 required:
                 - name
                 type: object
               serviceSelector:
                 description: |-
                   ServiceSelector selects Kubernetes Services by labels to use as output addresses.
-                  Supported for: nats, jetstream, kafka outputs.
+                  Supported for: nats, jetstream, kafka, remote_write, influxdb outputs.
                   All matching service addresses will be resolved and injected into the output config.
                 properties:
                   matchLabels:
@@ -112,6 +120,11 @@ spec:
                     description: |-
                       Port is the name or number of the port to use.
                       If not specified, the first port of the service is used.
+                    type: string
+                  url:
+                    description: |-
+                      URL is an optional path suffix appended after each resolved service address.
+                      Same semantics as ServiceReference.url (see ServiceReference).
                     type: string
                 required:
                 - matchLabels

--- a/helm/crds/operator.gnmic.dev_subscriptions.yaml
+++ b/helm/crds/operator.gnmic.dev_subscriptions.yaml
@@ -66,11 +66,28 @@ spec:
               heartbeatInterval:
                 description: The gNMI Subscription heartbeat interval
                 type: string
+              history:
+                description: The gNMI Subscription history configuration
+                properties:
+                  end:
+                    description: The gNMI Subscription history end time
+                    format: date-time
+                    type: string
+                  snapshot:
+                    description: The gNMI Subscription history snapshot time
+                    format: date-time
+                    type: string
+                  start:
+                    description: The gNMI Subscription history start time
+                    format: date-time
+                    type: string
+                type: object
               mode:
                 description: The gNMI SubscriptionList mode (ONCE, STREAM/SAMPLE,
                   STREAM/ON_CHANGE, STREAM/TARGET_DEFINED or POLL)
                 enum:
                 - ONCE
+                - STREAM
                 - STREAM/SAMPLE
                 - STREAM/ON_CHANGE
                 - STREAM/TARGET_DEFINED
@@ -84,6 +101,10 @@ spec:
               prefix:
                 description: The gNMI prefix to subscribe to
                 type: string
+              qos:
+                description: The gNMI Subscription QoS (0-9)
+                format: int32
+                type: integer
               sampleInterval:
                 description: The gNMI Subscription sample interval
                 type: string
@@ -92,6 +113,12 @@ spec:
                 items:
                   type: string
                 type: array
+              suppressRedundant:
+                description: Whether to suppress redundant updates
+                type: boolean
+              target:
+                description: The gNMI target to subscribe to
+                type: string
               updatesOnly:
                 description: Whether to only send updates or all data
                 type: boolean

--- a/helm/crds/operator.gnmic.dev_targetprofiles.yaml
+++ b/helm/crds/operator.gnmic.dev_targetprofiles.yaml
@@ -49,6 +49,7 @@ spec:
                   username, password or token keys in the secret referenced by the field
                 type: string
               encoding:
+                default: JSON
                 description: The gNMI Subscription encoding (JSON, BYTES, PROTO, ASCII,
                   JSON_IETF)
                 enum:
@@ -94,6 +95,7 @@ spec:
                 description: The TCP keep-alive interval
                 type: string
               timeout:
+                default: 10s
                 description: Target connection timeout
                 type: string
               tls:

--- a/helm/crds/operator.gnmic.dev_targets.yaml
+++ b/helm/crds/operator.gnmic.dev_targets.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .spec.profile
       name: Profile
       type: string
+    - jsonPath: .status.clusters
+      name: Clusters
+      type: integer
+    - jsonPath: .status.connectionState
+      name: State
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -57,24 +63,59 @@ spec:
             - profile
             type: object
           status:
-            description: TargetStatus defines the observed state of Target
+            description: |-
+              TargetStatus defines the observed state of Target.
+              A single Target may be collected by multiple Clusters (via different Pipelines),
+              so the status is reported per-cluster.
             properties:
+              clusterStates:
+                additionalProperties:
+                  description: ClusterTargetState represents the state of a target
+                    on a specific gNMIc cluster pod.
+                  properties:
+                    connectionState:
+                      description: The gNMI connection state (CONNECTING, READY, TRANSIENT_FAILURE,
+                        etc.).
+                      type: string
+                    failedReason:
+                      description: The reason for failure when state is "failed".
+                      type: string
+                    lastUpdated:
+                      description: When this state was last updated by the gNMIc pod.
+                      format: date-time
+                      type: string
+                    pod:
+                      description: The pod within the cluster that currently owns
+                        this target.
+                      type: string
+                    state:
+                      description: The target's operational state (starting, running,
+                        stopping, stopped, failed).
+                      type: string
+                    subscriptions:
+                      additionalProperties:
+                        type: string
+                      description: Per-subscription state (subscription name -> running/stopped).
+                      type: object
+                  required:
+                  - pod
+                  type: object
+                description: |-
+                  Per-cluster target state, keyed by Cluster CR name.
+                  A target may be collected by multiple clusters (via different pipelines).
+                type: object
+              clusters:
+                description: Number of clusters currently collecting this target.
+                format: int32
+                type: integer
               connectionState:
-                description: The connection state of the target
-                type: string
-              lastConnected:
-                format: date-time
-                type: string
-              lastDisconnected:
-                format: date-time
-                type: string
-              lastError:
+                description: |-
+                  Aggregate state across all clusters.
+                  READY if all clusters report running and READY, DEGRADED if any do not.
+                  Empty when no clusters are collecting this target.
                 type: string
             required:
-            - connectionState
-            - lastConnected
-            - lastDisconnected
-            - lastError
+            - clusters
             type: object
         type: object
     served: true

--- a/helm/crds/operator.gnmic.dev_targetsources.yaml
+++ b/helm/crds/operator.gnmic.dev_targetsources.yaml
@@ -39,136 +39,493 @@ spec:
           spec:
             description: TargetSourceSpec defines the desired state of TargetSource
             properties:
-              configMap:
-                type: string
-              consul:
+              provider:
+                description: |-
+                  Provider defines the source of targets for this TargetSource
+                  Only one provider can be specified per TargetSource
                 properties:
-                  url:
-                    type: string
+                  http:
+                    description: HTTP defines the configuration for a HTTP provider
+                    properties:
+                      authentication:
+                        description: Optional authentication configuration for accessing
+                          the HTTP endpoint
+                        properties:
+                          basic:
+                            description: Basic authentication configuration
+                            properties:
+                              credentialSecretRef:
+                                description: |-
+                                  Reference to a Secret containing "username" and "password" keys to use for
+                                  basic authentication when connecting to the Provider.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - credentialSecretRef
+                            type: object
+                          token:
+                            description: Token-based authentication configuration
+                            properties:
+                              scheme:
+                                description: Scheme for the token, e.g. "Bearer"
+                                minLength: 1
+                                type: string
+                              tokenSecretRef:
+                                description: |-
+                                  Reference to a Secret containing a key with the token value to use for
+                                  authentication when connecting to the Provider.
+                                  Mutually exclusive with Token.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - scheme
+                            - tokenSecretRef
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: exactly one of the fields in [basic token] must
+                            be set
+                          rule: '[has(self.basic),has(self.token)].filter(x,x==true).size()
+                            == 1'
+                      body:
+                        description: |-
+                          Optional raw request body.
+
+                          Typically used with POST requests and contains JSON payload.
+
+                          Example:
+                            body: |
+                              {
+                                "limit": 100,
+                                "status": "active"
+                              }
+
+                          Notes:
+                          - Ignored for GET requests
+                          - User must set appropriate Content-Type header if needed
+                        type: string
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Optional HTTP headers to include in the request.
+
+                          These map directly to HTTP headers (key-value pairs).
+
+                          Example:
+                            headers:
+                              Content-Type: application/json
+                              X-Custom-Header: value
+
+                          Precedence:
+                          - Authentication configuration overrides any conflicting headers e.g. Authorization
+                        type: object
+                      interval:
+                        default: 30m
+                        description: Optional interval for polling the HTTP endpoint
+                          for targets
+                        type: string
+                      mapping:
+                        description: Optional mapping configuration for parsing responses
+                          from the HTTP endpoint
+                        properties:
+                          address:
+                            description: |-
+                              CEL expression for the target address.
+
+                              If not set, defaults to:
+                                item["address"]
+
+                              Example:
+                                "item.ip"
+                            type: string
+                          labels:
+                            description: |-
+                              CEL expression that returns a map of labels.
+                              The expression must evaluate to an object (map).
+
+                              Example:
+
+                                labels: |
+                                  {
+                                    "env": item.environment,
+                                    "region": self.meta.region,
+                                    item.dynamicKey: "value"
+                                  }
+
+                              If not set, defaults to:
+                                item["labels"]
+
+                              The resulting map will be converted into labels.
+                              The extracted labels will be merged with the static TargetLabels defined in the TargetSourceSpec,
+                              with values from the response taking precedence in case of conflicts.
+                            type: string
+                          name:
+                            description: |-
+                              CEL expression for the target name.
+
+                              If not set, defaults to:
+                                item["name"]
+
+                              Example:
+                                "item.hostname"
+                            type: string
+                          port:
+                            description: |-
+                              CEL expression for the target port.
+
+                              If not set, defaults to:
+                                item["port"]
+
+                              Example:
+                                "item.port"
+                            type: string
+                          targetProfile:
+                            description: |-
+                              CEL expression for the target profile.
+
+                              If not set, defaults to:
+                                item["targetProfile"]
+
+                              Example:
+                                "item.type == 'edge' ? 'edge-profile' : 'default'"
+                            type: string
+                          targetsField:
+                            description: |-
+                              CEL expression that selects the list of target objects from the response.
+
+                              This is evaluated once using:
+                                self -> full JSON response
+
+                              Example:
+                                targetsField: "self.results"
+
+                              If not set, the response itself must be a JSON array with the targets.
+                            type: string
+                        type: object
+                      method:
+                        default: GET
+                        description: |-
+                          HTTP method used for the request.
+
+                          Defaults to GET if not specified.
+
+                          Supported values:
+                          - GET  (default, no request body)
+                          - POST (supports request body)
+                        enum:
+                        - GET
+                        - POST
+                        type: string
+                      pagination:
+                        description: Optional pagination configuration for parsing
+                          responses from the HTTP endpoint
+                        properties:
+                          nextField:
+                            description: |-
+                              CEL expression used to extract the next page reference from the response.
+
+                              The expression is evaluated with:
+                                self -> full JSON response
+
+                              It must evaluate to either:
+                                - string (full URL OR token), or
+                                - null (indicates end of pagination)
+
+                              Examples:
+                                "self.next"
+                                "self.next_page_token"
+                                "self['@odata.nextLink']"
+                            type: string
+                          requestParam:
+                            description: |-
+                              Query parameter name used when the extracted value is a token.
+
+                              Required for token-based pagination.
+                              Ignored when NextField resolves to a full URL.
+
+                              Example:
+                                requestParam: "page_token"
+                            type: string
+                        type: object
+                      push:
+                        description: Optional configuration to enable push
+                        properties:
+                          auth:
+                            properties:
+                              bearer:
+                                properties:
+                                  tokenSecretRef:
+                                    description: SecretKeySelector selects a key of
+                                      a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              signature:
+                                properties:
+                                  algorithm:
+                                    default: sha512
+                                    enum:
+                                    - sha1
+                                    - sha256
+                                    - sha512
+                                    type: string
+                                  header:
+                                    description: Header containing the signature
+                                    minLength: 1
+                                    type: string
+                                  secretRef:
+                                    description: SecretKeySelector selects a key of
+                                      a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - algorithm
+                                - header
+                                - secretRef
+                                type: object
+                            type: object
+                            x-kubernetes-validations:
+                            - message: exactly one of the fields in [bearer signature]
+                                must be set
+                              rule: '[has(self.bearer),has(self.signature)].filter(x,x==true).size()
+                                == 1'
+                          enabled:
+                            default: false
+                            type: boolean
+                        required:
+                        - enabled
+                        type: object
+                      timeout:
+                        default: 30s
+                        description: Optional timeout for HTTP requests to the endpoint
+                        type: string
+                      tls:
+                        description: |-
+                          Optional TLS configuration for connecting to the HTTP endpoint
+                          If it is an HTTP endpoint, this will be ignored
+                        properties:
+                          caBundleRef:
+                            description: |-
+                              Reference to a ConfigMap containing a bundle of PEM-encoded CAs to use when
+                              verifying the certificate chain presented by the Provider when using HTTPS.
+                              Mutually exclusive with CABundle.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          insecureSkipVerify:
+                            default: false
+                            description: Skip TLS verification of the Provider's certificate.
+                            type: boolean
+                        type: object
+                      url:
+                        description: |-
+                          URL of the HTTP endpoint to pull targets from
+                          If defined, the loader will periodically poll this endpoint for targets
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of the fields in [url push] must be set
+                      rule: '[has(self.url),has(self.push)].filter(x,x==true).size()
+                        >= 1'
                 type: object
-              http:
-                properties:
-                  url:
-                    type: string
-                type: object
-              labels:
+                x-kubernetes-validations:
+                - message: exactly one of the fields in [http] must be set
+                  rule: '[has(self.http)].filter(x,x==true).size() == 1'
+              targetLabels:
                 additionalProperties:
                   type: string
+                description: Optional labels to apply to all targets discovered by
+                  this TargetSource
                 type: object
-              podSelector:
-                description: |-
-                  A label selector is a label query over a set of resources. The result of matchLabels and
-                  matchExpressions are ANDed. An empty label selector matches all objects. A null
-                  label selector matches no objects.
-                properties:
-                  matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
-                    items:
-                      description: |-
-                        A label selector requirement is a selector that contains values, a key, and an operator that
-                        relates the key and values.
-                      properties:
-                        key:
-                          description: key is the label key that the selector applies
-                            to.
-                          type: string
-                        operator:
-                          description: |-
-                            operator represents a key's relationship to a set of values.
-                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                          type: string
-                        values:
-                          description: |-
-                            values is an array of string values. If the operator is In or NotIn,
-                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                            the values array must be empty. This array is replaced during a strategic
-                            merge patch.
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      required:
-                      - key
-                      - operator
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                    type: object
-                type: object
-                x-kubernetes-map-type: atomic
-              serviceSelector:
-                description: |-
-                  A label selector is a label query over a set of resources. The result of matchLabels and
-                  matchExpressions are ANDed. An empty label selector matches all objects. A null
-                  label selector matches no objects.
-                properties:
-                  matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
-                    items:
-                      description: |-
-                        A label selector requirement is a selector that contains values, a key, and an operator that
-                        relates the key and values.
-                      properties:
-                        key:
-                          description: key is the label key that the selector applies
-                            to.
-                          type: string
-                        operator:
-                          description: |-
-                            operator represents a key's relationship to a set of values.
-                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                          type: string
-                        values:
-                          description: |-
-                            values is an array of string values. If the operator is In or NotIn,
-                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                            the values array must be empty. This array is replaced during a strategic
-                            merge patch.
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      required:
-                      - key
-                      - operator
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                    type: object
-                type: object
-                x-kubernetes-map-type: atomic
+              targetPort:
+                description: Optional port to use for discovered targets if not specified
+                  by the provider
+                format: int32
+                type: integer
+              targetProfile:
+                description: Optional TargetProfile to use for targets discovered
+                  by this TargetSource if not specified by the provider
+                type: string
+            required:
+            - provider
             type: object
           status:
             description: TargetSourceStatus defines the observed state of TargetSource
             properties:
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the
+                  TargetSource's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               lastSync:
                 format: date-time
                 type: string
+              observedGeneration:
+                format: int64
+                type: integer
               status:
                 type: string
               targetsCount:
                 format: int32
                 type: integer
             required:
-            - lastSync
-            - status
-            - targetsCount
+            - observedGeneration
             type: object
         type: object
     served: true

--- a/helm/templates/clusterrole.yaml
+++ b/helm/templates/clusterrole.yaml
@@ -88,6 +88,7 @@ rules:
     resources:
       - clusters/status
       - pipelines/status
+      - targets/status
       - targetsources/status
       - tunneltargetpolicies/status
     verbs:

--- a/helm/templates/metrics-service.yaml
+++ b/helm/templates/metrics-service.yaml
@@ -10,7 +10,7 @@ spec:
     - port: {{ .Values.metrics.port }}
       targetPort: metrics
       protocol: TCP
-      name: https
+      name: metrics
   selector:
     {{- include "gnmic-operator.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -10,14 +10,11 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: https
+    - port: metrics
       path: /metrics
-      scheme: https
+      scheme: http
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
-      tlsConfig:
-        insecureSkipVerify: true
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
## What does this change resolve?
- The Helm chart deploys outdated CRDs. This PR syncs them by running `make helm-crds`
- The Helm chart ClusterRole is missing permissions to manage the `status` of `Target` resources. This PR adds this configuration
- Metric scraping doesn't work. This PR implements these fixes:
  - Do not scrape Webhook Service since it doesn't expose the /metrics endpoint
  - Target the `metrics` port in the Metrics Service using the `http` scheme instead of `https`
- Add a small CI check to ensure Helm CRDs are up to date

> [!NOTE]
> I didn't bump the chart version because the current version is not yet released.
>
> Also, please let me know if you would like the Helm CRDs CI check to be a separate step in the workflow. I added it along with manifest generation because it felt like an integral part of it.