### PR TITLE
test: add gnmi-gen integration harness and test suites

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/client-go v0.36.3
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -65,10 +66,12 @@ require (
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -113,9 +116,9 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260501160325-927ab1f70cd6 // indirect
+	k8s.io/streaming v0.36.3 // indirect
 	sigs.k8s.io/gateway-api v1.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
@@ -119,6 +121,8 @@ github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 h1:EwtI+Al+DeppwYX2oX
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -141,6 +145,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -297,6 +303,8 @@ k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
 k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kube-openapi v0.0.0-20260501160325-927ab1f70cd6 h1:ngxu1nL4SbFuXwu1EY7cSKcVqSjTQPVbYQT6WNjTXaU=
 k8s.io/kube-openapi v0.0.0-20260501160325-927ab1f70cd6/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
+k8s.io/streaming v0.36.3 h1:9rAaqBk0C0Pc7+/fqGekj07NV+/Xrew58p647A0JT8w=
+k8s.io/streaming v0.36.3/go.mod h1:z6fV3D+NVkoeqRMtWwlUZK6U17SY/LqNzOxWL6GyR/s=
 k8s.io/utils v0.0.0-20260626114624-be93311217bd h1:Ea7fgQ5we8Y9T0OX5o0dAHzQOBRI07D/dEYRaB9ZZEs=
 k8s.io/utils v0.0.0-20260626114624-be93311217bd/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -59,6 +59,7 @@ import (
 	gnmicv1alpha1 "github.com/gnmic/operator/api/v1alpha1"
 	"github.com/gnmic/operator/internal/gnmic"
 	"github.com/gnmic/operator/internal/utils"
+	gapi "github.com/openconfig/gnmic/pkg/api/types"
 )
 
 // ClusterReconciler reconciles a Cluster object
@@ -498,6 +499,15 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		logger.Info("waiting for gNMIc pods to be ready before applying config")
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
+	// A reconcile queued while Pipelines were empty can run after a newer
+	// reconcile already applied a non-empty plan. Re-list immediately before
+	// apply and bail out if membership moved under us.
+	if fresh, err := r.listPipelinesForCluster(ctx, &cluster); err != nil {
+		return ctrl.Result{}, err
+	} else if !pipelineSetEqual(pipelines, fresh) {
+		logger.Info("pipelines changed during reconcile, requeueing before apply")
+		return ctrl.Result{Requeue: true}, nil
+	}
 	// send the plan to all gNMIc pods with distributed targets
 	// distrubute to desired replicas only, this makes redistribution fast in case of scaling down.
 	numPods := int(desiredReplicas)
@@ -645,16 +655,49 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 		}
 	}
-	// update status if changed
+	// Re-fetch before comparing: a concurrent reconcile may have already
+	// written a newer status, and comparing against the start-of-reconcile
+	// copy can skip a needed update (e.g. stale empty reconcile sees
+	// pipelinesCount=0 in-memory while the live status is still 1).
+	clusterNN := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+	if err := r.Get(ctx, clusterNN, &cluster); err != nil {
+		return ctrl.Result{}, err
+	}
 	if !clusterStatusEqual(cluster.Status, newStatus) {
-		cluster.Status = newStatus
-		if err := r.Status().Update(ctx, &cluster); err != nil {
-			logger.Error(err, "failed to update cluster status")
+		var statusErr error
+		for attempt := 0; attempt < 5; attempt++ {
+			if attempt > 0 {
+				if err := r.Get(ctx, clusterNN, &cluster); err != nil {
+					statusErr = err
+					break
+				}
+			}
+			cluster.Status = newStatus
+			if err := r.Status().Update(ctx, &cluster); err != nil {
+				if apierrors.IsConflict(err) {
+					statusErr = err
+					continue
+				}
+				statusErr = err
+				break
+			}
+			statusErr = nil
+			break
+		}
+		if statusErr != nil {
+			logger.Error(statusErr, "failed to update cluster status")
+			return ctrl.Result{}, statusErr
 		}
 	}
 
 	if configError != nil {
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+	// An empty apply from a briefly stale cache can race a Pipeline create.
+	// Requeue once so the next pass sees the live membership and restores
+	// config if needed; non-empty applies are left alone.
+	if configApplied && len(pipelines) == 0 {
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil
@@ -702,27 +745,80 @@ func (r *ClusterReconciler) applyConfigToPods(ctx context.Context, cluster *gnmi
 		return 0, fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 	distResult := gnmic.DistributeTargets(plan, numPods, cluster.Spec.TargetDistribution)
-	// apply config to each pod with distributed targets
+
+	scheme := "http"
+	if cluster.Spec.API != nil && cluster.Spec.API.TLS != nil && cluster.Spec.API.TLS.IssuerRef != "" {
+		scheme = "https"
+	}
+	podURL := func(podIndex int) string {
+		// statefulSet pods have predictable DNS names:
+		//  <statefulset-name>-<ordinal>.<service-name>.<namespace>.svc.<cluster-domain>
+		podDNS := fmt.Sprintf("%s-%d.%s.%s.svc.%s", stsName, podIndex, stsName, cluster.Namespace, gnmic.ClusterDomain())
+		return fmt.Sprintf("%s://%s:%d/api/v1/config/apply", scheme, podDNS, restPort)
+	}
+
+	// Two-phase apply avoids double-collection when a target moves between pods.
+	// A single ordered pass can start the new owner before the old owner has
+	// dropped the target (e.g. moving from pod 2 to pod 0). Phase 1 shrinks
+	// each pod to the intersection of its previous and next assignment so
+	// movers are stopped everywhere; phase 2 installs the full new sets.
+	// Pods that are about to disappear on scale-down are drained explicitly.
+	if len(plan.CurrentTargetAssignment) > 0 {
+		template, ok := distResult.PerPodPlans[0]
+		if !ok {
+			for _, p := range distResult.PerPodPlans {
+				template = p
+				break
+			}
+		}
+		for podIndex := range plan.CurrentTargetAssignment {
+			if podIndex < numPods {
+				continue
+			}
+			if template == nil {
+				break
+			}
+			drain := shrinkPodPlan(template, nil)
+			url := podURL(podIndex)
+			logger.Info("draining gNMIc pod before scale-down", "url", url)
+			if err := r.sendApplyRequest(ctx, url, drain, httpClient); err != nil {
+				// The pod may already be gone; do not fail the reconcile for that.
+				logger.Info("drain of scaled-down pod failed (continuing)", "pod", podIndex, "error", err)
+			}
+		}
+		for podIndex := 0; podIndex < numPods; podIndex++ {
+			podPlan, ok := distResult.PerPodPlans[podIndex]
+			if !ok {
+				continue
+			}
+			shrink := shrinkPodPlan(podPlan, plan.CurrentTargetAssignment[podIndex])
+			url := podURL(podIndex)
+			logger.Info("shrinking gNMIc pod targets before reassignment", "url", url, "targets", len(shrink.Targets))
+			if err := r.sendApplyRequest(ctx, url, shrink, httpClient); err != nil {
+				return 0, fmt.Errorf("failed to shrink config on pod %d: %w", podIndex, err)
+			}
+		}
+		// gNMIc's config/apply returns before Subscribe streams are fully torn
+		// down. Give movers a beat to drop on the old owner before phase 2
+		// starts them on the new one; otherwise a scale transition briefly
+		// double-collects.
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+
 	for podIndex := 0; podIndex < numPods; podIndex++ {
-		// distribute targets for this pod
 		podPlan, ok := distResult.PerPodPlans[podIndex]
 		if !ok {
 			continue
 		}
-		// build the URL for this pod
-		// statefulSet pods have predictable DNS names:
-		//  <statefulset-name>-<ordinal>.<service-name>.<namespace>.svc.<cluster-domain>
-		podDNS := fmt.Sprintf("%s-%d.%s.%s.svc.%s", stsName, podIndex, stsName, cluster.Namespace, gnmic.ClusterDomain())
-		scheme := "http"
-		if cluster.Spec.API != nil && cluster.Spec.API.TLS != nil && cluster.Spec.API.TLS.IssuerRef != "" {
-			scheme = "https"
-		}
-		url := fmt.Sprintf("%s://%s:%d/api/v1/config/apply", scheme, podDNS, restPort)
+		url := podURL(podIndex)
 		logger.Info("sending config to gNMIc pod", "url", url)
 		if err := r.sendApplyRequest(ctx, url, podPlan, httpClient); err != nil {
 			return 0, fmt.Errorf("failed to apply config to pod %d: %w", podIndex, err)
 		}
-
 		logger.Info("config applied to pod", "pod", podIndex, "targets", len(podPlan.Targets))
 	}
 
@@ -811,6 +907,33 @@ func (r *ClusterReconciler) getIssuerCA(ctx context.Context, namespace, issuerNa
 	}
 
 	return caCert, nil
+}
+
+// shrinkPodPlan returns a copy of podPlan whose Targets are the intersection of
+// the desired set and the pod's previously assigned targets. A nil previous set
+// yields an empty target map — used to drain a pod.
+func shrinkPodPlan(podPlan *gnmic.ApplyPlan, previous map[string]struct{}) *gnmic.ApplyPlan {
+	out := &gnmic.ApplyPlan{
+		Targets:             maps.Clone(podPlan.Targets),
+		Subscriptions:       podPlan.Subscriptions,
+		Outputs:             podPlan.Outputs,
+		Inputs:              podPlan.Inputs,
+		Processors:          podPlan.Processors,
+		TunnelTargetMatches: podPlan.TunnelTargetMatches,
+	}
+	if out.Targets == nil {
+		out.Targets = make(map[string]*gapi.TargetConfig)
+	}
+	clear(out.Targets)
+	if previous == nil {
+		return out
+	}
+	for name, cfg := range podPlan.Targets {
+		if _, ok := previous[name]; ok {
+			out.Targets[name] = cfg
+		}
+	}
+	return out
 }
 
 // sendApplyRequest sends an apply plan to a single gNMIc pod
@@ -2122,6 +2245,22 @@ func (r *ClusterReconciler) listPipelinesForCluster(ctx context.Context, cluster
 		}
 	}
 	return result, nil
+}
+
+func pipelineSetEqual(a, b []gnmicv1alpha1.Pipeline) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	names := make(map[string]struct{}, len(a))
+	for i := range a {
+		names[a[i].Name] = struct{}{}
+	}
+	for i := range b {
+		if _, ok := names[b[i].Name]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // buildConfigContent builds the gnmic configuration from the cluster and its pipelines

--- a/internal/gnmic/distribute.go
+++ b/internal/gnmic/distribute.go
@@ -37,9 +37,12 @@ func DistributeTargets(plan *ApplyPlan, numPods int, targetDistribution *v1alpha
 	}
 	newAssignment := placement.distributeTargets(plan.Targets, placementOptions)
 
+	// Always emit a plan for every pod, including when there are no targets.
+	// An empty PerPodPlans map would skip apply entirely and leave collectors
+	// streaming after the last Pipeline is deleted or disabled.
 	assigned := make(map[string]struct{})
-	result := make(map[int]*ApplyPlan)
-	for podIndex, targets := range newAssignment {
+	result := make(map[int]*ApplyPlan, numPods)
+	for podIndex := 0; podIndex < numPods; podIndex++ {
 		result[podIndex] = &ApplyPlan{
 			Targets:             make(map[string]*gapi.TargetConfig),
 			Subscriptions:       plan.Subscriptions,
@@ -48,8 +51,15 @@ func DistributeTargets(plan *ApplyPlan, numPods int, targetDistribution *v1alpha
 			Processors:          plan.Processors,
 			TunnelTargetMatches: plan.TunnelTargetMatches,
 		}
+	}
+	for podIndex, targets := range newAssignment {
+		podPlan, ok := result[podIndex]
+		if !ok {
+			// Placement returned a pod outside 0..numPods-1; ignore.
+			continue
+		}
 		for _, targetNN := range targets {
-			result[podIndex].Targets[targetNN] = plan.Targets[targetNN]
+			podPlan.Targets[targetNN] = plan.Targets[targetNN]
 			assigned[targetNN] = struct{}{}
 		}
 	}

--- a/internal/gnmic/distribute_test.go
+++ b/internal/gnmic/distribute_test.go
@@ -152,6 +152,32 @@ func TestDistributeTargetsEdgeCases(t *testing.T) {
 	}
 }
 
+func TestDistributeTargets_EmptyTargetsStillEmitsPodPlans(t *testing.T) {
+	plan := &ApplyPlan{
+		Targets:       map[string]*gapi.TargetConfig{},
+		Subscriptions: map[string]*gapi.SubscriptionConfig{},
+		Outputs:       map[string]map[string]any{},
+		Inputs:        map[string]map[string]any{},
+	}
+	numPods := 2
+	distResult := DistributeTargets(plan, numPods, nil)
+	if len(distResult.PerPodPlans) != numPods {
+		t.Fatalf("expected %d pod plans, got %d", numPods, len(distResult.PerPodPlans))
+	}
+	for i := 0; i < numPods; i++ {
+		dp, ok := distResult.PerPodPlans[i]
+		if !ok {
+			t.Fatalf("missing plan for pod %d", i)
+		}
+		if len(dp.Targets) != 0 {
+			t.Errorf("pod %d: expected empty targets, got %d", i, len(dp.Targets))
+		}
+	}
+	if len(distResult.UnassignedTargets) != 0 {
+		t.Errorf("unexpected unassigned: %v", distResult.UnassignedTargets)
+	}
+}
+
 func TestDistributeTargets_CapacityOverflow(t *testing.T) {
 	plan := &ApplyPlan{
 		Targets: map[string]*gapi.TargetConfig{

--- a/test.mk
+++ b/test.mk
@@ -177,3 +177,96 @@ apply-test-clusters: ## Apply the test clusters for testing
 .PHONY: apply-test-resources
 apply-test-resources: apply-test-targets apply-test-subscriptions apply-test-outputs apply-test-pipelines apply-test-clusters apply-test-targetsources
 
+##@ Integration Suite
+
+# The assertion-driven suite under test/integration/suite, backed by simulated
+# devices. It runs on its own kind cluster so it never contends with
+# run-integration-tests for a cluster name, a topology, or a port; the two can
+# run at the same time.
+
+IT_CLUSTER_NAME ?= gnmic-it
+IT_CONTEXT      := kind-$(IT_CLUSTER_NAME)
+IT_KUBECTL      := kubectl --context $(IT_CONTEXT)
+IT_OPERATOR_IMG ?= gnmic-operator:integration
+GNMIGEN_IMAGE   ?= registry.kmrd.dev/gnmic/gnmigen:0.0.0
+GNMIC_IMAGE     ?= ghcr.io/openconfig/gnmic:0.46.0
+# A second pinned tag, so rollout tests can prove an image change took effect.
+GNMIC_IMAGE_ALT ?= ghcr.io/openconfig/gnmic:0.44.0-amd64
+IT_SUITE_DIR    := test/integration/suite
+IT_TIMEOUT      ?= 30m
+IT_PARALLEL     ?= 2
+
+export GNMIGEN_IMAGE
+export GNMIC_IMAGE
+export GNMIC_IMAGE_ALT
+
+.PHONY: integration-env-up
+integration-env-up: install-kind ## Create the integration kind cluster and deploy the operator into it
+	@if kind get clusters 2>/dev/null | grep -qx "$(IT_CLUSTER_NAME)"; then \
+		echo "kind cluster $(IT_CLUSTER_NAME) already exists"; \
+	else \
+		kind create cluster --name $(IT_CLUSTER_NAME); \
+	fi
+	$(IT_KUBECTL) apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
+	@echo "waiting for cert-manager..."
+	$(IT_KUBECTL) wait --namespace cert-manager --for=condition=Available deployment --all --timeout=180s
+	$(MAKE) integration-images
+	$(MAKE) integration-deploy-operator
+
+.PHONY: integration-images
+integration-images: ## Build the operator image and load it, gnmi-gen and gnmic into the integration cluster
+	$(MAKE) docker-build IMG=$(IT_OPERATOR_IMG)
+	kind load docker-image $(IT_OPERATOR_IMG) --name $(IT_CLUSTER_NAME)
+	@for img in $(GNMIGEN_IMAGE) $(GNMIC_IMAGE) $(GNMIC_IMAGE_ALT); do \
+		docker image inspect $$img >/dev/null 2>&1 || docker pull $$img; \
+		kind load docker-image $$img --name $(IT_CLUSTER_NAME); \
+	done
+
+# `make deploy` runs `kustomize edit set image`, which rewrites
+# config/manager/kustomization.yaml in place. Restore it so running the
+# integration suite never leaves a diff in the working tree.
+define it_deploy
+	$(MAKE) deploy IMG=$(IT_OPERATOR_IMG) KUBECTL="$(IT_KUBECTL)"; \
+	status=$$?; \
+	git checkout -- config/manager/kustomization.yaml 2>/dev/null || true; \
+	exit $$status
+endef
+
+.PHONY: integration-deploy-operator
+integration-deploy-operator: ## Deploy or redeploy the operator into the integration cluster
+	@$(it_deploy)
+	@echo "waiting for the operator to be available..."
+	$(IT_KUBECTL) wait --namespace gnmic-system --for=condition=Available deployment/gnmic-controller-manager --timeout=180s
+
+.PHONY: integration-env-refresh
+integration-env-refresh: ## Rebuild the operator image and restart it, without recreating the cluster
+	$(MAKE) integration-images
+	@$(it_deploy)
+	$(IT_KUBECTL) -n gnmic-system rollout restart deployment/gnmic-controller-manager
+	$(IT_KUBECTL) -n gnmic-system rollout status deployment/gnmic-controller-manager --timeout=180s
+
+.PHONY: integration-env-down
+integration-env-down: ## Delete the integration kind cluster
+	kind delete cluster --name $(IT_CLUSTER_NAME) || true
+
+.PHONY: integration-env-check
+integration-env-check: ## Fail fast with an actionable message if the integration environment is not ready
+	@kind get clusters 2>/dev/null | grep -qx "$(IT_CLUSTER_NAME)" || \
+		{ echo "kind cluster $(IT_CLUSTER_NAME) not found. Run: make integration-env-up"; exit 1; }
+	@$(IT_KUBECTL) get deployment/gnmic-controller-manager -n gnmic-system >/dev/null 2>&1 || \
+		{ echo "operator not deployed in $(IT_CLUSTER_NAME). Run: make integration-env-up"; exit 1; }
+	@$(IT_KUBECTL) wait --namespace gnmic-system --for=condition=Available deployment/gnmic-controller-manager --timeout=60s
+
+.PHONY: integration-test
+integration-test: integration-env-check ## Run every integration suite
+	go test -tags=integration -count=1 -p $(IT_PARALLEL) -timeout $(IT_TIMEOUT) -v ./$(IT_SUITE_DIR)/...
+
+# Run one suite by directory name, e.g. make integration-test-000-spike
+.PHONY: integration-test-%
+integration-test-%: integration-env-check ## Run a single suite, e.g. make integration-test-001-cluster
+	go test -tags=integration -count=1 -timeout $(IT_TIMEOUT) -v ./$(IT_SUITE_DIR)/$*/...
+
+.PHONY: integration-suites
+integration-suites: ## List the available integration suites
+	@ls -1 $(IT_SUITE_DIR)
+

--- a/test/integration/harness/conditions.go
+++ b/test/integration/harness/conditions.go
@@ -1,0 +1,188 @@
+//go:build integration
+
+package harness
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Condition types set by the operator. Mirrors the constants in
+// internal/controller/cluster_controller.go.
+const (
+	CondReady             = "Ready"
+	CondCertificatesReady = "CertificatesReady"
+	CondConfigApplied     = "ConfigApplied"
+	CondCapacityExhausted = "CapacityExhausted"
+	CondResourcesResolved = "ResourcesResolved"
+)
+
+// WaitClusterCondition waits for a condition on a Cluster.
+func WaitClusterCondition(t *testing.T, k *K8s, name, condType string, want metav1.ConditionStatus, timeout time.Duration) {
+	t.Helper()
+	Wait(t, timeout, fmt.Sprintf("Cluster %s condition %s=%s", name, condType, want), func() (bool, string) {
+		c, err := k.clusterQuiet(name)
+		if err != nil {
+			return false, err.Error()
+		}
+		cond := meta.FindStatusCondition(c.Status.Conditions, condType)
+		if cond == nil {
+			return false, "condition not present"
+		}
+		return cond.Status == want, fmt.Sprintf("status=%s reason=%s message=%s", cond.Status, cond.Reason, cond.Message)
+	})
+}
+
+// WaitClusterReady waits for a Cluster to report Ready.
+func WaitClusterReady(t *testing.T, k *K8s, name string) {
+	t.Helper()
+	WaitClusterCondition(t, k, name, CondReady, metav1.ConditionTrue, Long)
+}
+
+// WaitConfigApplied waits for a Cluster to report that it pushed its rendered
+// config to the collector pods.
+func WaitConfigApplied(t *testing.T, k *K8s, name string) {
+	t.Helper()
+	WaitClusterCondition(t, k, name, CondConfigApplied, metav1.ConditionTrue, Medium)
+}
+
+// ClusterCounts declares the status counters a test cares about. Nil fields are
+// not checked, so a test stays silent about counters it is not asserting.
+type ClusterCounts struct {
+	ReadyReplicas      *int32
+	PipelinesCount     *int32
+	TargetsCount       *int32
+	SubscriptionsCount *int32
+	InputsCount        *int32
+	OutputsCount       *int32
+	UnassignedTargets  *int32
+}
+
+// I32 is a convenience for building ClusterCounts.
+func I32(v int32) *int32 { return &v }
+
+// WaitClusterCounts waits until every declared counter matches.
+func WaitClusterCounts(t *testing.T, k *K8s, name string, want ClusterCounts) {
+	t.Helper()
+	Wait(t, Medium, fmt.Sprintf("Cluster %s status counters", name), func() (bool, string) {
+		c, err := k.clusterQuiet(name)
+		if err != nil {
+			return false, err.Error()
+		}
+		got := ClusterCounts{
+			ReadyReplicas:      &c.Status.ReadyReplicas,
+			PipelinesCount:     &c.Status.PipelinesCount,
+			TargetsCount:       &c.Status.TargetsCount,
+			SubscriptionsCount: &c.Status.SubscriptionsCount,
+			InputsCount:        &c.Status.InputsCount,
+			OutputsCount:       &c.Status.OutputsCount,
+			UnassignedTargets:  &c.Status.UnassignedTargets,
+		}
+		type pair struct {
+			name       string
+			want, have *int32
+		}
+		for _, p := range []pair{
+			{"readyReplicas", want.ReadyReplicas, got.ReadyReplicas},
+			{"pipelinesCount", want.PipelinesCount, got.PipelinesCount},
+			{"targetsCount", want.TargetsCount, got.TargetsCount},
+			{"subscriptionsCount", want.SubscriptionsCount, got.SubscriptionsCount},
+			{"inputsCount", want.InputsCount, got.InputsCount},
+			{"outputsCount", want.OutputsCount, got.OutputsCount},
+			{"unassignedTargets", want.UnassignedTargets, got.UnassignedTargets},
+		} {
+			if p.want != nil && *p.want != *p.have {
+				return false, fmt.Sprintf("%s: want %d, got %d", p.name, *p.want, *p.have)
+			}
+		}
+		return true, ""
+	})
+}
+
+// WaitTargetState waits for a Target's aggregate connection state.
+func WaitTargetState(t *testing.T, k *K8s, name, want string) {
+	t.Helper()
+	Wait(t, Medium, fmt.Sprintf("Target %s connectionState=%s", name, want), func() (bool, string) {
+		tgt, err := k.targetQuiet(name)
+		if err != nil {
+			return false, err.Error()
+		}
+		return tgt.Status.State == want, fmt.Sprintf("state=%q clusters=%d", tgt.Status.State, tgt.Status.Clusters)
+	})
+}
+
+// TargetPod reports which collector pod currently owns a target for a cluster.
+func TargetPod(t *testing.T, k *K8s, target, cluster string) string {
+	t.Helper()
+	tgt, err := k.targetQuiet(target)
+	if err != nil {
+		return ""
+	}
+	return tgt.Status.ClusterStates[cluster].Pod
+}
+
+// PipelineCounts declares the Pipeline status counters a test cares about.
+type PipelineCounts struct {
+	TargetsCount       *int32
+	SubscriptionsCount *int32
+	OutputsCount       *int32
+	InputsCount        *int32
+}
+
+// WaitPipelineCounts waits until every declared Pipeline counter matches.
+func WaitPipelineCounts(t *testing.T, k *K8s, name string, want PipelineCounts) {
+	t.Helper()
+	Wait(t, Medium, fmt.Sprintf("Pipeline %s status counters", name), func() (bool, string) {
+		p, err := k.pipelineQuiet(name)
+		if err != nil {
+			return false, err.Error()
+		}
+		type pair struct {
+			name       string
+			want, have *int32
+		}
+		for _, x := range []pair{
+			{"targetsCount", want.TargetsCount, &p.Status.TargetsCount},
+			{"subscriptionsCount", want.SubscriptionsCount, &p.Status.SubscriptionsCount},
+			{"outputsCount", want.OutputsCount, &p.Status.OutputsCount},
+			{"inputsCount", want.InputsCount, &p.Status.InputsCount},
+		} {
+			if x.want != nil && *x.want != *x.have {
+				return false, fmt.Sprintf("%s: want %d, got %d", x.name, *x.want, *x.have)
+			}
+		}
+		return true, ""
+	})
+}
+
+// WaitPipelineCondition waits for a condition on a Pipeline.
+func WaitPipelineCondition(t *testing.T, k *K8s, name, condType string, want metav1.ConditionStatus) {
+	t.Helper()
+	Wait(t, Medium, fmt.Sprintf("Pipeline %s condition %s=%s", name, condType, want), func() (bool, string) {
+		p, err := k.pipelineQuiet(name)
+		if err != nil {
+			return false, err.Error()
+		}
+		cond := meta.FindStatusCondition(p.Status.Conditions, condType)
+		if cond == nil {
+			return false, "condition not present"
+		}
+		return cond.Status == want, fmt.Sprintf("status=%s reason=%s", cond.Status, cond.Reason)
+	})
+}
+
+// WaitPipelineStatusString waits for Pipeline.status.status to equal want.
+func WaitPipelineStatusString(t *testing.T, k *K8s, name, want string) {
+	t.Helper()
+	Wait(t, Medium, fmt.Sprintf("Pipeline %s status=%s", name, want), func() (bool, string) {
+		p, err := k.pipelineQuiet(name)
+		if err != nil {
+			return false, err.Error()
+		}
+		return p.Status.Status == want, "status=" + p.Status.Status
+	})
+}

--- a/test/integration/harness/exec.go
+++ b/test/integration/harness/exec.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package harness
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Exec runs a command inside a pod container and returns its stdout.
+//
+// Used to read what a collector actually has on disk, as opposed to what the
+// ConfigMap says it should have.
+func (k *K8s) Exec(t *testing.T, pod, container string, command ...string) string {
+	t.Helper()
+	req := k.Clientset.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Name(pod).
+		Namespace(k.Namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: container,
+			Command:   command,
+			Stdout:    true,
+			Stderr:    true,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(k.RestCfg, http.MethodPost, req.URL())
+	if err != nil {
+		t.Fatalf("building executor for %s: %v", pod, err)
+	}
+	var stdout, stderr bytes.Buffer
+	err = exec.StreamWithContext(k.Ctx, remotecommand.StreamOptions{Stdout: &stdout, Stderr: &stderr})
+	if err != nil {
+		t.Fatalf("exec %v in %s: %v (stderr: %s)", command, pod, err, stderr.String())
+	}
+	return stdout.String()
+}
+
+// CollectorAPI opens a port-forward to a collector pod's REST API and returns a
+// GET function against it. The forward closes when the test ends.
+func (k *K8s) CollectorAPI(t *testing.T, pod string, restPort int) func(path string) (int, string) {
+	t.Helper()
+	fw, err := k.ForwardPodPort(pod, restPort)
+	if err != nil {
+		t.Fatalf("port-forwarding %s:%d: %v", pod, restPort, err)
+	}
+	t.Cleanup(fw.Close)
+
+	return func(path string) (int, string) {
+		resp, err := http.Get(fw.URL + path)
+		if err != nil {
+			return 0, err.Error()
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, string(body)
+	}
+}
+
+// AssertOwnedBy checks that an object carries an owner reference to the named
+// owner. Garbage collection depends on this, and a missing owner reference
+// otherwise only surfaces much later as objects left behind.
+func AssertOwnedBy(t *testing.T, obj client.Object, ownerKind, ownerName string) {
+	t.Helper()
+	refs := obj.GetOwnerReferences()
+	for _, ref := range refs {
+		if ref.Kind == ownerKind && ref.Name == ownerName {
+			return
+		}
+	}
+	var have []string
+	for _, r := range refs {
+		have = append(have, fmt.Sprintf("%s/%s", r.Kind, r.Name))
+	}
+	if len(have) == 0 {
+		have = []string{"<none>"}
+	}
+	t.Fatalf("%s has no owner reference to %s/%s; owners are %v", obj.GetName(), ownerKind, ownerName, have)
+}

--- a/test/integration/harness/fixtures.go
+++ b/test/integration/harness/fixtures.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+package harness
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+// baseVars are available to every fixture template. Target addresses embed the
+// suite namespace, which is why fixtures are templates rather than static files.
+func (k *K8s) baseVars() map[string]any {
+	return map[string]any{
+		"Namespace":    k.Namespace,
+		"GnmiGenHost":  GnmiGenHost(k.Namespace),
+		"GnmiGenImage": GnmiGenImage(),
+		"GnmicImage":   GnmicImage(),
+	}
+}
+
+// render executes a fixture template with the suite variables plus any
+// per-call overrides.
+//
+// Missing keys are an error rather than an empty string: a typo in a fixture
+// should surface as a failure, not as a Target with no address.
+func (k *K8s) render(text string, vars map[string]any) (string, error) {
+	data := k.baseVars()
+	for key, v := range vars {
+		data[key] = v
+	}
+	tmpl, err := template.New("fixture").Option("missingkey=error").Parse(text)
+	if err != nil {
+		return "", fmt.Errorf("parsing template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("rendering template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// GnmiGenHost is the in-cluster DNS name of a suite's simulator. Because the
+// Service is headless this resolves to the pod IP, so any simulated target port
+// is reachable without being declared on the Service.
+func GnmiGenHost(namespace string) string {
+	return fmt.Sprintf("gnmi-gen.%s.svc.cluster.local", namespace)
+}
+
+// GnmiGenAddress is the dial address of simulated target n, 0-based.
+func GnmiGenAddress(namespace string, n int) string {
+	return fmt.Sprintf("%s:%d", GnmiGenHost(namespace), 57400+n)
+}
+
+func GnmiGenImage() string {
+	return getenv("GNMIGEN_IMAGE", "registry.kmrd.dev/gnmic/gnmigen:0.0.0")
+}
+
+func GnmicImage() string {
+	return getenv("GNMIC_IMAGE", "ghcr.io/openconfig/gnmic:0.46.0")
+}

--- a/test/integration/harness/gnmigen.go
+++ b/test/integration/harness/gnmigen.go
@@ -1,0 +1,311 @@
+//go:build integration
+
+package harness
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// GnmiGen is the device-side ground truth client: what the collectors actually
+// did on the wire, observed without trusting the collector's own API.
+type GnmiGen struct {
+	BaseURL string // http://127.0.0.1:<forwarded>/api/v1
+	http    *http.Client
+}
+
+func NewGnmiGen(baseURL string) *GnmiGen {
+	return &GnmiGen{
+		BaseURL: baseURL + "/api/v1",
+		http:    &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// SimTarget is one simulated device.
+type SimTarget struct {
+	Name             string `json:"name"`
+	Listen           string `json:"listen"`
+	TLS              bool   `json:"tls"`
+	Status           string `json:"status"` // starting | up | rebooting
+	PathCount        int    `json:"path_count"`
+	UptimeSeconds    int    `json:"uptime_seconds"`
+	RebootCount      int    `json:"reboot_count"`
+	RebootConfigured bool   `json:"reboot_configured"`
+}
+
+// SubEntry is one path entry of a client's SubscribeRequest.
+type SubEntry struct {
+	Path              string `json:"path"`
+	Mode              string `json:"mode"`
+	SampleInterval    string `json:"sample_interval"`
+	HeartbeatInterval string `json:"heartbeat_interval"`
+	SuppressRedundant bool   `json:"suppress_redundant"`
+}
+
+// Subscription is one open Subscribe stream on a simulated device.
+type Subscription struct {
+	ID                      string     `json:"id"`
+	EstablishedAt           time.Time  `json:"established_at"`
+	Mode                    string     `json:"mode"`
+	Prefix                  string     `json:"prefix"`
+	Encoding                string     `json:"encoding"`
+	AllPaths                bool       `json:"all_paths"`
+	Paths                   []string   `json:"paths"`
+	Entries                 []SubEntry `json:"subscription_entries"`
+	EffectiveSampleInterval string     `json:"effective_sample_interval"`
+	NotificationsSent       int        `json:"notifications_sent"`
+	SyncMessagesSent        int        `json:"sync_messages_sent"`
+	UpdatesOnly             bool       `json:"updates_only"`
+}
+
+func (g *GnmiGen) getInto(path string, out any) error {
+	resp, err := g.http.Get(g.BaseURL + path)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: %s: %s", path, resp.Status, string(body))
+	}
+	return json.Unmarshal(body, out)
+}
+
+// Targets returns every simulated target keyed by name.
+func (g *GnmiGen) Targets() (map[string]SimTarget, error) {
+	var resp struct {
+		Targets []SimTarget `json:"targets"`
+	}
+	if err := g.getInto("/targets", &resp); err != nil {
+		return nil, err
+	}
+	out := make(map[string]SimTarget, len(resp.Targets))
+	for _, t := range resp.Targets {
+		out[t.Name] = t
+	}
+	return out, nil
+}
+
+// Target returns one simulated target.
+func (g *GnmiGen) Target(name string) (SimTarget, error) {
+	var t SimTarget
+	err := g.getInto("/targets/"+name, &t)
+	return t, err
+}
+
+// Subscriptions returns the open Subscribe streams on a target. An unknown or
+// idle target yields an empty slice rather than an error, so callers can poll.
+func (g *GnmiGen) Subscriptions(target string) ([]Subscription, error) {
+	var resp struct {
+		Target        string         `json:"target"`
+		Subscriptions []Subscription `json:"subscriptions"`
+	}
+	if err := g.getInto("/subscriptions/"+target, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Subscriptions, nil
+}
+
+// StreamCount is the number of open Subscribe streams on a target.
+//
+// gNMIc opens one stream per Subscription, so a target collected by one pod
+// under three subscriptions shows three streams, not one. Duplicate collection
+// therefore shows up as a multiple of the expected count rather than as 2.
+func (g *GnmiGen) StreamCount(target string) int {
+	subs, err := g.Subscriptions(target)
+	if err != nil {
+		return -1
+	}
+	return len(subs)
+}
+
+// Paths returns the union of resolved leaf paths across a target's streams.
+func (g *GnmiGen) Paths(target string) []string {
+	subs, err := g.Subscriptions(target)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range subs {
+		for _, p := range s.Paths {
+			if !seen[p] {
+				seen[p] = true
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+// Notifications is the total notification count across a target's streams.
+func (g *GnmiGen) Notifications(target string) int {
+	subs, err := g.Subscriptions(target)
+	if err != nil {
+		return -1
+	}
+	total := 0
+	for _, s := range subs {
+		total += s.NotificationsSent
+	}
+	return total
+}
+
+// EstablishedAt is the earliest established_at among a target's open streams.
+// Zero means no stream is open. Used to prove a stream was not torn down and
+// re-created across a placement change.
+func (g *GnmiGen) EstablishedAt(target string) time.Time {
+	subs, err := g.Subscriptions(target)
+	if err != nil || len(subs) == 0 {
+		return time.Time{}
+	}
+	earliest := subs[0].EstablishedAt
+	for _, s := range subs[1:] {
+		if !s.EstablishedAt.IsZero() && (earliest.IsZero() || s.EstablishedAt.Before(earliest)) {
+			earliest = s.EstablishedAt
+		}
+	}
+	return earliest
+}
+
+// Reboot injects a connection outage. With no targets named, all are rebooted.
+func (g *GnmiGen) Reboot(downtime time.Duration, targets ...string) error {
+	body, _ := json.Marshal(map[string]any{
+		"targets":  targets,
+		"downtime": downtime.String(),
+	})
+	resp, err := g.http.Post(g.BaseURL+"/targets/reboot", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("reboot: %s: %s", resp.Status, string(raw))
+	}
+	var out struct {
+		Results []struct {
+			Target   string `json:"target"`
+			Accepted bool   `json:"accepted"`
+			Error    string `json:"error"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return err
+	}
+	for _, r := range out.Results {
+		if !r.Accepted {
+			return fmt.Errorf("reboot of %s not accepted: %s", r.Target, r.Error)
+		}
+	}
+	return nil
+}
+
+// --- polling assertions --------------------------------------------------
+
+// WaitTargetsUp blocks until every named simulated target reports "up".
+func (g *GnmiGen) WaitTargetsUp(t *testing.T, names ...string) {
+	t.Helper()
+	Wait(t, Medium, fmt.Sprintf("gnmi-gen targets %v to be up", names), func() (bool, string) {
+		targets, err := g.Targets()
+		if err != nil {
+			return false, "API not answering: " + err.Error()
+		}
+		for _, n := range names {
+			tgt, ok := targets[n]
+			if !ok {
+				return false, fmt.Sprintf("target %s not registered", n)
+			}
+			if tgt.Status != "up" {
+				return false, fmt.Sprintf("target %s is %s", n, tgt.Status)
+			}
+		}
+		return true, ""
+	})
+}
+
+// WaitStreams blocks until a target has exactly want open Subscribe streams.
+func (g *GnmiGen) WaitStreams(t *testing.T, target string, want int) {
+	t.Helper()
+	Wait(t, Medium, fmt.Sprintf("%d subscribe stream(s) on %s", want, target), func() (bool, string) {
+		got := g.StreamCount(target)
+		return got == want, fmt.Sprintf("want %d, got %d", want, got)
+	})
+}
+
+// WaitPathPresent blocks until a target's streams include path.
+func (g *GnmiGen) WaitPathPresent(t *testing.T, target, path string) {
+	t.Helper()
+	Wait(t, Medium, fmt.Sprintf("path %s on %s", path, target), func() (bool, string) {
+		paths := g.Paths(target)
+		for _, p := range paths {
+			if p == path {
+				return true, ""
+			}
+		}
+		return false, fmt.Sprintf("paths are %v", paths)
+	})
+}
+
+// WaitPathAbsent blocks until a target's streams no longer include path.
+// Removal assertions are where the interesting operator bugs live.
+func (g *GnmiGen) WaitPathAbsent(t *testing.T, target, path string) {
+	t.Helper()
+	Wait(t, Medium, fmt.Sprintf("path %s gone from %s", path, target), func() (bool, string) {
+		for _, p := range g.Paths(target) {
+			if p == path {
+				return false, "still present"
+			}
+		}
+		return true, ""
+	})
+}
+
+// WaitNotificationsAdvance blocks until a target's notification counter grows,
+// proving data is actually flowing rather than a stream merely being open.
+func (g *GnmiGen) WaitNotificationsAdvance(t *testing.T, target string) {
+	t.Helper()
+	start := g.Notifications(target)
+	Wait(t, Medium, fmt.Sprintf("notifications to advance on %s", target), func() (bool, string) {
+		now := g.Notifications(target)
+		return now > start, fmt.Sprintf("still at %d (started at %d)", now, start)
+	})
+}
+
+// AssertCollectedOnce checks the suite's central invariant: every target is
+// collected exactly once cluster-wide. Duplicate collection double-counts
+// metrics; missing collection loses data silently.
+//
+// perTarget is the number of Subscriptions bound to each target, which is the
+// stream count a single collector produces. Passing the wrong number here turns
+// the assertion into a tautology, so tests state it explicitly rather than
+// defaulting it.
+func (g *GnmiGen) AssertCollectedOnce(t *testing.T, perTarget int, targets ...string) {
+	t.Helper()
+	for _, target := range targets {
+		g.WaitStreams(t, target, perTarget)
+	}
+}
+
+// ConsistentlyCollectedOnce holds the invariant over a window, since
+// distribution bugs often flap rather than settle wrong.
+func (g *GnmiGen) ConsistentlyCollectedOnce(t *testing.T, dur time.Duration, perTarget int, targets ...string) {
+	t.Helper()
+	desc := fmt.Sprintf("exactly %d stream(s) per target", perTarget)
+	Consistently(t, dur, time.Second, desc, func() (bool, string) {
+		for _, target := range targets {
+			if got := g.StreamCount(target); got != perTarget {
+				return false, fmt.Sprintf("%s has %d streams, want %d", target, got, perTarget)
+			}
+		}
+		return true, ""
+	})
+}

--- a/test/integration/harness/k8s.go
+++ b/test/integration/harness/k8s.go
@@ -1,0 +1,484 @@
+//go:build integration
+
+package harness
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gnmicv1alpha1 "github.com/gnmic/operator/api/v1alpha1"
+)
+
+// FieldOwner identifies this suite's server-side apply writes.
+const FieldOwner = client.FieldOwner("gnmic-integration-tests")
+
+// K8s is the suite's handle on the cluster. Every helper is namespace-scoped to
+// the suite namespace unless it says otherwise.
+type K8s struct {
+	Client    client.Client
+	Clientset *kubernetes.Clientset
+	RestCfg   *rest.Config
+	Namespace string
+	Ctx       context.Context
+}
+
+// Scheme returns the scheme used by the harness client: core Kubernetes, the
+// operator's CRDs, and cert-manager.
+func Scheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	must(clientgoscheme.AddToScheme(s))
+	must(gnmicv1alpha1.AddToScheme(s))
+	must(certmanagerv1.AddToScheme(s))
+	return s
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// NewK8s connects to the integration cluster.
+//
+// The context is pinned rather than inherited from whatever the shell happens
+// to have selected: these tests create and delete namespaces, and pointing them
+// at the wrong cluster is not a mistake worth allowing. IT_CONTEXT overrides.
+func NewK8s(ctx context.Context, namespace string) (*K8s, error) {
+	kubeContext := getenv("IT_CONTEXT", "kind-"+getenv("IT_CLUSTER_NAME", "gnmic-it"))
+
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules,
+		&clientcmd.ConfigOverrides{CurrentContext: kubeContext},
+	).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("building client config for context %q: %w", kubeContext, err)
+	}
+	cfg.QPS, cfg.Burst = 50, 100
+
+	c, err := client.New(cfg, client.Options{Scheme: Scheme()})
+	if err != nil {
+		return nil, fmt.Errorf("building client: %w", err)
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("building clientset: %w", err)
+	}
+	return &K8s{Client: c, Clientset: cs, RestCfg: cfg, Namespace: namespace, Ctx: ctx}, nil
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// Apply server-side applies an object into the suite namespace and registers
+// cleanup so the test does not have to.
+func (k *K8s) Apply(t *testing.T, obj client.Object) {
+	t.Helper()
+	if obj.GetNamespace() == "" {
+		obj.SetNamespace(k.Namespace)
+	}
+	if err := k.Client.Patch(k.Ctx, obj, client.Apply, FieldOwner, client.ForceOwnership); err != nil {
+		t.Fatalf("applying %T %s: %v", obj, obj.GetName(), err)
+	}
+	t.Cleanup(func() { k.deleteQuietly(obj) })
+}
+
+// ApplyNoCleanup applies without registering cleanup, for suite baselines whose
+// lifetime is the whole package rather than one test.
+func (k *K8s) ApplyNoCleanup(obj client.Object) error {
+	if obj.GetNamespace() == "" {
+		obj.SetNamespace(k.Namespace)
+	}
+	return k.Client.Patch(k.Ctx, obj, client.Apply, FieldOwner, client.ForceOwnership)
+}
+
+// ApplyYAMLNoCleanup renders and applies YAML without registering cleanup.
+func (k *K8s) ApplyYAMLNoCleanup(yaml string, vars map[string]any) ([]client.Object, error) {
+	return k.applyYAML(yaml, vars)
+}
+
+// ApplyYAML renders a multi-document YAML string as a template, applies every
+// document, and registers cleanup in reverse order.
+func (k *K8s) ApplyYAML(t *testing.T, yaml string, vars map[string]any) []client.Object {
+	t.Helper()
+	objs, err := k.applyYAML(yaml, vars)
+	if err != nil {
+		t.Fatalf("applying YAML: %v", err)
+	}
+	t.Cleanup(func() {
+		for i := len(objs) - 1; i >= 0; i-- {
+			k.deleteQuietly(objs[i])
+		}
+	})
+	return objs
+}
+
+// ApplyFile is ApplyYAML for a file on disk, relative to the suite directory.
+func (k *K8s) ApplyFile(t *testing.T, path string, vars map[string]any) []client.Object {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", path, err)
+	}
+	return k.ApplyYAML(t, string(b), vars)
+}
+
+func (k *K8s) applyYAML(yamlText string, vars map[string]any) ([]client.Object, error) {
+	rendered, err := k.render(yamlText, vars)
+	if err != nil {
+		return nil, err
+	}
+	docs, err := splitYAML(rendered)
+	if err != nil {
+		return nil, err
+	}
+	var applied []client.Object
+	for _, doc := range docs {
+		u := &unstructured.Unstructured{Object: doc}
+		if u.GetNamespace() == "" {
+			u.SetNamespace(k.Namespace)
+		}
+		if err := k.Client.Patch(context.Background(), u, client.Apply, FieldOwner, client.ForceOwnership); err != nil {
+			return applied, fmt.Errorf("applying %s/%s: %w", u.GetKind(), u.GetName(), err)
+		}
+		applied = append(applied, u)
+	}
+	return applied, nil
+}
+
+func splitYAML(text string) ([]map[string]any, error) {
+	var out []map[string]any
+	dec := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(text)), 4096)
+	for {
+		var doc map[string]any
+		err := dec.Decode(&doc)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(doc) == 0 {
+			continue
+		}
+		out = append(out, doc)
+	}
+	return out, nil
+}
+
+func (k *K8s) deleteQuietly(obj client.Object) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := k.Client.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		fmt.Fprintf(os.Stderr, "cleanup: deleting %s/%s: %v\n", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), err)
+	}
+}
+
+// Delete removes an object and waits for it to actually disappear. Cleanup that
+// does not verify removal poisons the next test.
+func (k *K8s) Delete(t *testing.T, obj client.Object) {
+	t.Helper()
+	if err := k.Client.Delete(k.Ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("deleting %s: %v", obj.GetName(), err)
+	}
+	key := client.ObjectKeyFromObject(obj)
+	Wait(t, Short, fmt.Sprintf("%s to be gone", obj.GetName()), func() (bool, string) {
+		err := k.Client.Get(k.Ctx, key, obj)
+		if apierrors.IsNotFound(err) {
+			return true, ""
+		}
+		return false, "still present"
+	})
+}
+
+// Patch applies a raw merge patch to a named object.
+func (k *K8s) Patch(t *testing.T, obj client.Object, patch string) {
+	t.Helper()
+	if err := k.Client.Patch(k.Ctx, obj, client.RawPatch(types.MergePatchType, []byte(patch))); err != nil {
+		t.Fatalf("patching %s: %v", obj.GetName(), err)
+	}
+}
+
+// --- typed getters -------------------------------------------------------
+
+func (k *K8s) get(t *testing.T, name string, obj client.Object) {
+	t.Helper()
+	if err := k.Client.Get(k.Ctx, types.NamespacedName{Namespace: k.Namespace, Name: name}, obj); err != nil {
+		t.Fatalf("getting %T %s: %v", obj, name, err)
+	}
+}
+
+func (k *K8s) Cluster(t *testing.T, name string) *gnmicv1alpha1.Cluster {
+	t.Helper()
+	o := &gnmicv1alpha1.Cluster{}
+	k.get(t, name, o)
+	return o
+}
+
+func (k *K8s) Pipeline(t *testing.T, name string) *gnmicv1alpha1.Pipeline {
+	t.Helper()
+	o := &gnmicv1alpha1.Pipeline{}
+	k.get(t, name, o)
+	return o
+}
+
+func (k *K8s) Target(t *testing.T, name string) *gnmicv1alpha1.Target {
+	t.Helper()
+	o := &gnmicv1alpha1.Target{}
+	k.get(t, name, o)
+	return o
+}
+
+// WaitExists blocks until a named object exists, then leaves it in obj.
+func (k *K8s) WaitExists(t *testing.T, name string, obj client.Object) {
+	t.Helper()
+	kind := obj.GetObjectKind().GroupVersionKind().Kind
+	if kind == "" {
+		kind = fmt.Sprintf("%T", obj)
+	}
+	Wait(t, Medium, fmt.Sprintf("%s %s to exist", kind, name), func() (bool, string) {
+		err := k.Client.Get(k.Ctx, types.NamespacedName{Namespace: k.Namespace, Name: name}, obj)
+		if err == nil {
+			return true, ""
+		}
+		if apierrors.IsNotFound(err) {
+			return false, "not created yet"
+		}
+		return false, err.Error()
+	})
+}
+
+// WaitAbsent blocks until a named object is gone. Garbage-collection
+// assertions need this as much as creation assertions need WaitExists.
+func (k *K8s) WaitAbsent(t *testing.T, name string, obj client.Object) {
+	t.Helper()
+	Wait(t, Medium, fmt.Sprintf("%s to be deleted", name), func() (bool, string) {
+		err := k.Client.Get(k.Ctx, types.NamespacedName{Namespace: k.Namespace, Name: name}, obj)
+		if apierrors.IsNotFound(err) {
+			return true, ""
+		}
+		if err != nil {
+			return false, err.Error()
+		}
+		return false, "still present"
+	})
+}
+
+// clusterQuiet and targetQuiet return an error instead of failing the test, so
+// polling helpers can retry a not-found or a stale cache.
+func (k *K8s) clusterQuiet(name string) (*gnmicv1alpha1.Cluster, error) {
+	o := &gnmicv1alpha1.Cluster{}
+	err := k.Client.Get(k.Ctx, types.NamespacedName{Namespace: k.Namespace, Name: name}, o)
+	return o, err
+}
+
+func (k *K8s) targetQuiet(name string) (*gnmicv1alpha1.Target, error) {
+	o := &gnmicv1alpha1.Target{}
+	err := k.Client.Get(k.Ctx, types.NamespacedName{Namespace: k.Namespace, Name: name}, o)
+	return o, err
+}
+
+// TargetQuiet is the non-fatal form of Target, for polling helpers.
+func (k *K8s) TargetQuiet(name string) (*gnmicv1alpha1.Target, error) {
+	return k.targetQuiet(name)
+}
+
+func (k *K8s) pipelineQuiet(name string) (*gnmicv1alpha1.Pipeline, error) {
+	o := &gnmicv1alpha1.Pipeline{}
+	err := k.Client.Get(k.Ctx, types.NamespacedName{Namespace: k.Namespace, Name: name}, o)
+	return o, err
+}
+
+// DeleteNow deletes without waiting for absence. Use for objects the operator
+// or a controller will recreate immediately (e.g. a StatefulSet pod).
+func (k *K8s) DeleteNow(t *testing.T, obj client.Object) {
+	t.Helper()
+	if obj.GetNamespace() == "" {
+		obj.SetNamespace(k.Namespace)
+	}
+	if err := k.Client.Delete(k.Ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("deleting %s: %v", obj.GetName(), err)
+	}
+}
+
+func (k *K8s) StatefulSet(t *testing.T, name string) *appsv1.StatefulSet {
+	t.Helper()
+	o := &appsv1.StatefulSet{}
+	k.get(t, name, o)
+	return o
+}
+
+func (k *K8s) Service(t *testing.T, name string) *corev1.Service {
+	t.Helper()
+	o := &corev1.Service{}
+	k.get(t, name, o)
+	return o
+}
+
+func (k *K8s) ConfigMap(t *testing.T, name string) *corev1.ConfigMap {
+	t.Helper()
+	o := &corev1.ConfigMap{}
+	k.get(t, name, o)
+	return o
+}
+
+// --- pods ----------------------------------------------------------------
+
+// Pods lists pods in the suite namespace matching labels.
+func (k *K8s) Pods(t *testing.T, labels map[string]string) []corev1.Pod {
+	t.Helper()
+	var list corev1.PodList
+	if err := k.Client.List(k.Ctx, &list, client.InNamespace(k.Namespace), client.MatchingLabels(labels)); err != nil {
+		t.Fatalf("listing pods: %v", err)
+	}
+	return list.Items
+}
+
+// ClusterPods lists the collector pods of a gNMIc cluster.
+func (k *K8s) ClusterPods(t *testing.T, cluster string) []corev1.Pod {
+	t.Helper()
+	return k.Pods(t, map[string]string{LabelClusterName: cluster})
+}
+
+// WaitReadyPods blocks until a cluster has exactly want Ready collector pods.
+// Exactly, not at least: scale-down is only proven by the surplus going away.
+func (k *K8s) WaitReadyPods(t *testing.T, cluster string, want int, timeout time.Duration) []corev1.Pod {
+	t.Helper()
+	var ready []corev1.Pod
+	Wait(t, timeout, fmt.Sprintf("%d ready pod(s) in cluster %s", want, cluster), func() (bool, string) {
+		var list corev1.PodList
+		err := k.Client.List(k.Ctx, &list,
+			client.InNamespace(k.Namespace),
+			client.MatchingLabels{LabelClusterName: cluster})
+		if err != nil {
+			return false, err.Error()
+		}
+		ready = nil
+		for i := range list.Items {
+			if podReady(&list.Items[i]) {
+				ready = append(ready, list.Items[i])
+			}
+		}
+		return len(ready) == want, fmt.Sprintf("%d ready of %d total", len(ready), len(list.Items))
+	})
+	return ready
+}
+
+// WaitPodGone blocks until a named pod no longer exists.
+func (k *K8s) WaitPodGone(t *testing.T, name string) {
+	t.Helper()
+	k.WaitAbsent(t, name, &corev1.Pod{})
+}
+
+// RestartCounts snapshots container restart counts, so a test can prove a
+// config change was applied dynamically rather than by restarting pods.
+func (k *K8s) RestartCounts(t *testing.T, cluster string) map[string]int32 {
+	t.Helper()
+	out := map[string]int32{}
+	for _, p := range k.ClusterPods(t, cluster) {
+		var total int32
+		for _, cs := range p.Status.ContainerStatuses {
+			total += cs.RestartCount
+		}
+		out[p.Name] = total
+	}
+	return out
+}
+
+// AssertNoRestarts fails if any pod present in both snapshots restarted.
+func AssertNoRestarts(t *testing.T, before, after map[string]int32) {
+	t.Helper()
+	for pod, b := range before {
+		a, ok := after[pod]
+		if !ok {
+			continue // pod replaced; scaling tests assert on that separately
+		}
+		if a != b {
+			t.Fatalf("pod %s restarted during the change: %d -> %d", pod, b, a)
+		}
+	}
+}
+
+// Logs returns recent logs for a pod.
+func (k *K8s) Logs(t *testing.T, pod string, since time.Duration) string {
+	t.Helper()
+	sec := int64(since.Seconds())
+	req := k.Clientset.CoreV1().Pods(k.Namespace).GetLogs(pod, &corev1.PodLogOptions{SinceSeconds: &sec})
+	rc, err := req.Stream(k.Ctx)
+	if err != nil {
+		return fmt.Sprintf("<logs unavailable: %v>", err)
+	}
+	defer rc.Close()
+	b, _ := io.ReadAll(rc)
+	return string(b)
+}
+
+// AssertNoPanics fails if a log body contains a Go panic.
+func AssertNoPanics(t *testing.T, logs string) {
+	t.Helper()
+	if strings.Contains(logs, "panic: ") || strings.Contains(logs, "runtime error:") {
+		t.Fatalf("panic found in logs:\n%s", logs)
+	}
+}
+
+// --- namespaces ----------------------------------------------------------
+
+func (k *K8s) createNamespace(ctx context.Context) error {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   k.Namespace,
+		Labels: map[string]string{"gnmic.dev/integration-suite": "true"},
+	}}
+	// A previous run may have left the namespace terminating.
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		err := k.Client.Create(ctx, ns)
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		var existing corev1.Namespace
+		if getErr := k.Client.Get(ctx, types.NamespacedName{Name: k.Namespace}, &existing); getErr == nil &&
+			existing.Status.Phase != corev1.NamespaceTerminating {
+			return nil // usable as-is, e.g. a KEEP_NS re-run
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("namespace %s still terminating after 2m", k.Namespace)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func (k *K8s) deleteNamespace(ctx context.Context) error {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: k.Namespace}}
+	if err := k.Client.Delete(ctx, ns); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/test/integration/harness/manifests/gnmi-gen.yaml
+++ b/test/integration/harness/manifests/gnmi-gen.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gnmi-gen
+  namespace: {{ .Namespace }}
+  labels:
+    app: gnmi-gen
+spec:
+  # Headless on purpose. DNS resolves straight to the pod IP, so collectors can
+  # dial any simulated target port without it being enumerated here. A ClusterIP
+  # Service would require one entry per simulated target.
+  clusterIP: None
+  selector:
+    app: gnmi-gen
+  ports:
+    - name: api
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gnmi-gen
+  namespace: {{ .Namespace }}
+  labels:
+    app: gnmi-gen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gnmi-gen
+  template:
+    metadata:
+      labels:
+        app: gnmi-gen
+      annotations:
+        gnmi-gen.config/hash: "{{ .ConfigHash }}"
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: gnmi-gen
+          image: {{ .GnmiGenImage }}
+          imagePullPolicy: IfNotPresent
+          args: ["--config", "/config/gnmi-gen.yaml"]
+          ports:
+            - name: api
+              containerPort: 8080
+          volumeMounts:
+            - name: config
+              mountPath: /config
+          readinessProbe:
+            httpGet:
+              path: /api/v1/targets
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            failureThreshold: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: gnmi-gen-config

--- a/test/integration/harness/names.go
+++ b/test/integration/harness/names.go
@@ -1,0 +1,46 @@
+//go:build integration
+
+package harness
+
+import "fmt"
+
+// Labels the operator puts on the objects it owns. Mirrors
+// internal/controller/const.go; kept here so suites do not import internal
+// packages, and so a rename in the operator breaks in exactly one place.
+const (
+	LabelClusterName           = "operator.gnmic.dev/cluster"
+	LabelOutputName            = "operator.gnmic.dev/output"
+	LabelPipelineName          = "operator.gnmic.dev/pipeline"
+	LabelPodName               = "operator.gnmic.dev/pod-name"
+	LabelServiceType           = "operator.gnmic.dev/service-type"
+	LabelOutputType            = "operator.gnmic.dev/output-type"
+	LabelCertType              = "operator.gnmic.dev/cert-type"
+	LabelTargetSourceFinalizer = "operator.gnmic.dev/targetsource-finalizer"
+
+	ValueName                  = "gnmic"
+	ValueManagedBy             = "gnmic-operator"
+	ValueServiceTypeHeadless   = "rest-api"
+	ValueServiceTypeTunnel     = "tunnel"
+	ValueServiceTypePrometheus = "prometheus-output"
+	ValueCertTypeClient        = "client"
+	ValueCertTypeTunnel        = "tunnel"
+)
+
+const resourcePrefix = "gnmic-"
+
+// The operator's naming scheme for the objects it builds. Suites call these
+// rather than formatting names inline.
+
+func StatefulSetName(cluster string) string     { return resourcePrefix + cluster }
+func HeadlessServiceName(cluster string) string { return resourcePrefix + cluster }
+func ConfigMapName(cluster string) string       { return resourcePrefix + cluster + "-config" }
+func TunnelServiceName(cluster string) string   { return resourcePrefix + cluster + "-grpc-tunnel" }
+func ClientCertName(cluster string) string      { return resourcePrefix + cluster + "-client-tls" }
+
+func PromServiceName(cluster, pipeline, output string) string {
+	return fmt.Sprintf("%s%s-prom-%s-%s", resourcePrefix, cluster, pipeline, output)
+}
+
+func PodName(cluster string, ordinal int) string {
+	return fmt.Sprintf("%s%s-%d", resourcePrefix, cluster, ordinal)
+}

--- a/test/integration/harness/portforward.go
+++ b/test/integration/harness/portforward.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package harness
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Forward is an active port-forward into the cluster.
+type Forward struct {
+	LocalPort int
+	URL       string
+
+	stop chan struct{}
+}
+
+// Close tears the forward down.
+func (f *Forward) Close() {
+	select {
+	case <-f.stop:
+	default:
+		close(f.stop)
+	}
+}
+
+// ForwardPodPort forwards a container port on a specific pod.
+//
+// This uses client-go directly rather than shelling out to kubectl: no child
+// process to leak, failures arrive as Go errors, and the forward closes
+// deterministically when the suite ends.
+func (k *K8s) ForwardPodPort(pod string, remotePort int) (*Forward, error) {
+	transport, upgrader, err := spdy.RoundTripperFor(k.RestCfg)
+	if err != nil {
+		return nil, fmt.Errorf("building spdy transport: %w", err)
+	}
+	url := k.Clientset.CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Namespace(k.Namespace).
+		Name(pod).
+		SubResource("portforward").
+		URL()
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, url)
+
+	stop := make(chan struct{})
+	ready := make(chan struct{})
+	fw, err := portforward.New(dialer, []string{fmt.Sprintf("0:%d", remotePort)}, stop, ready, io.Discard, io.Discard)
+	if err != nil {
+		close(stop)
+		return nil, fmt.Errorf("creating port forwarder: %w", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- fw.ForwardPorts() }()
+
+	select {
+	case <-ready:
+	case err := <-errCh:
+		return nil, fmt.Errorf("port forward to %s:%d failed: %w", pod, remotePort, err)
+	case <-time.After(30 * time.Second):
+		close(stop)
+		return nil, fmt.Errorf("port forward to %s:%d timed out", pod, remotePort)
+	}
+
+	ports, err := fw.GetPorts()
+	if err != nil || len(ports) == 0 {
+		close(stop)
+		return nil, fmt.Errorf("resolving forwarded port: %w", err)
+	}
+	local := int(ports[0].Local)
+	return &Forward{
+		LocalPort: local,
+		URL:       fmt.Sprintf("http://127.0.0.1:%d", local),
+		stop:      stop,
+	}, nil
+}
+
+// ForwardService forwards a port on the first ready pod backing a Service.
+//
+// It targets a pod rather than the Service because port-forward is a pod-level
+// operation; picking the pod here keeps callers from having to know that.
+func (k *K8s) ForwardService(ctx context.Context, selector map[string]string, remotePort int) (*Forward, error) {
+	pod, err := k.firstReadyPod(ctx, selector)
+	if err != nil {
+		return nil, err
+	}
+	return k.ForwardPodPort(pod, remotePort)
+}
+
+func (k *K8s) firstReadyPod(ctx context.Context, selector map[string]string) (string, error) {
+	deadline := time.Now().Add(Medium)
+	for {
+		var pods corev1.PodList
+		err := k.Client.List(ctx, &pods, client.InNamespace(k.Namespace), client.MatchingLabels(selector))
+		if err == nil {
+			for _, p := range pods.Items {
+				if podReady(&p) {
+					return p.Name, nil
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("no ready pod matching %v in %s", selector, k.Namespace)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func podReady(p *corev1.Pod) bool {
+	if p.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, c := range p.Status.Conditions {
+		if c.Type == corev1.PodReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/test/integration/harness/suite.go
+++ b/test/integration/harness/suite.go
@@ -1,0 +1,363 @@
+//go:build integration
+
+// Package harness provides the shared machinery for the operator integration
+// suites under test/integration/suite.
+//
+// A suite is a Go package with a TestMain that calls RunSuite. The harness
+// gives it an isolated namespace, an in-cluster gnmi-gen simulator with a REST
+// client for device-side ground truth, polling assertion helpers, and
+// deterministic teardown.
+//
+// Everything here is behind the "integration" build tag and expects a running
+// cluster with the operator deployed: see `make integration-env-up`.
+package harness
+
+import (
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//go:embed manifests/gnmi-gen.yaml
+var gnmiGenManifests string
+
+// Options configures a suite. Set by each suite's TestMain.
+type Options struct {
+	// Name is the suite directory name, e.g. "003-targets". The namespace is
+	// derived from its numeric prefix.
+	Name string
+	// GnmiGenConfig is the simulator config, relative to the suite directory.
+	// Defaults to "gnmi-gen.yaml". Empty string disables the simulator, for
+	// suites that do not need one.
+	GnmiGenConfig string
+	// Baseline fixtures applied after the simulator is up, before m.Run.
+	Baseline []string
+	// RequireTargets are simulated targets that must report "up" before tests
+	// start.
+	RequireTargets []string
+}
+
+// Suite is the per-suite context, created once in TestMain and shared by every
+// test in the package.
+type Suite struct {
+	Name      string
+	Namespace string
+	K8s       *K8s
+	GnmiGen   *GnmiGen
+	Ctx       context.Context
+
+	forward *Forward
+	cancel  context.CancelFunc
+}
+
+// New brings a suite up: namespace, simulator, baseline fixtures.
+func New(opts Options) (*Suite, error) {
+	if opts.Name == "" {
+		return nil, fmt.Errorf("suite name is required")
+	}
+	if opts.GnmiGenConfig == "" {
+		opts.GnmiGenConfig = "gnmi-gen.yaml"
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	namespace := namespaceFor(opts.Name)
+
+	k, err := NewK8s(ctx, namespace)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	s := &Suite{Name: opts.Name, Namespace: namespace, K8s: k, Ctx: ctx, cancel: cancel}
+
+	if err := k.createNamespace(ctx); err != nil {
+		cancel()
+		return nil, fmt.Errorf("creating namespace: %w", err)
+	}
+	logf("suite %s: namespace %s ready", opts.Name, namespace)
+
+	if err := s.deployGnmiGen(opts.GnmiGenConfig); err != nil {
+		return s, fmt.Errorf("deploying gnmi-gen: %w", err)
+	}
+
+	if len(opts.RequireTargets) > 0 {
+		if err := s.waitTargetsUp(opts.RequireTargets); err != nil {
+			return s, err
+		}
+	}
+
+	for _, f := range opts.Baseline {
+		if err := s.applyBaseline(f); err != nil {
+			return s, fmt.Errorf("applying baseline %s: %w", f, err)
+		}
+	}
+	logf("suite %s: baseline applied", opts.Name)
+	return s, nil
+}
+
+// RunSuite is the standard TestMain body:
+//
+//	func TestMain(m *testing.M) {
+//	    os.Exit(harness.RunSuite(m, harness.Options{Name: "003-targets", ...}, &s))
+//	}
+//
+// The suite pointer is populated before m.Run so tests can reach it.
+func RunSuite(m *testing.M, opts Options, out **Suite) int {
+	s, err := New(opts)
+	if s != nil {
+		*out = s
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "suite setup failed: %v\n", err)
+		if s != nil {
+			s.Dump(os.Stderr)
+			s.teardown()
+		}
+		return 1
+	}
+
+	code := m.Run()
+	if code != 0 {
+		s.Dump(os.Stderr)
+	}
+	s.teardown()
+	return code
+}
+
+func (s *Suite) teardown() {
+	if s.forward != nil {
+		s.forward.Close()
+	}
+	if os.Getenv("KEEP_NS") == "1" {
+		logf("KEEP_NS=1, leaving namespace %s in place", s.Namespace)
+		logf("  kubectl -n %s get cluster,pipeline,target,pods", s.Namespace)
+		logf("  kubectl -n %s port-forward svc/gnmi-gen 8080:8080", s.Namespace)
+		s.cancel()
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	if err := s.K8s.deleteNamespace(ctx); err != nil {
+		logf("deleting namespace %s: %v", s.Namespace, err)
+	}
+	s.cancel()
+}
+
+// deployGnmiGen creates the simulator ConfigMap from the suite's config file,
+// applies the Deployment and headless Service, waits for readiness, and opens a
+// port-forward to the REST control plane.
+func (s *Suite) deployGnmiGen(configPath string) error {
+	cfg, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", configPath, err)
+	}
+
+	// The simulator config contains its own Go template syntax, which gnmi-gen
+	// expands at startup. It must not go through the fixture renderer.
+	sum := sha256.Sum256(cfg)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "gnmi-gen-config", Namespace: s.Namespace},
+		Data:       map[string]string{"gnmi-gen.yaml": string(cfg)},
+	}
+	cm.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+	if err := s.K8s.ApplyNoCleanup(cm); err != nil {
+		return fmt.Errorf("applying config: %w", err)
+	}
+
+	vars := map[string]any{"ConfigHash": hex.EncodeToString(sum[:8])}
+	if _, err := s.K8s.applyYAML(gnmiGenManifests, vars); err != nil {
+		return err
+	}
+
+	if err := s.waitDeploymentAvailable("gnmi-gen"); err != nil {
+		return err
+	}
+
+	fw, err := s.K8s.ForwardService(s.Ctx, map[string]string{"app": "gnmi-gen"}, 8080)
+	if err != nil {
+		return fmt.Errorf("port-forwarding gnmi-gen: %w", err)
+	}
+	s.forward = fw
+	s.GnmiGen = NewGnmiGen(fw.URL)
+	logf("suite %s: gnmi-gen REST at %s", s.Name, fw.URL)
+	return nil
+}
+
+func (s *Suite) waitDeploymentAvailable(name string) error {
+	deadline := time.Now().Add(Medium)
+	for {
+		var d appsv1.Deployment
+		err := s.K8s.Client.Get(s.Ctx, types.NamespacedName{Namespace: s.Namespace, Name: name}, &d)
+		if err == nil && d.Status.ReadyReplicas > 0 {
+			return nil
+		}
+		// A bad simulator config crash-loops rather than hanging. Waiting the
+		// full timeout to then report "not available" hides the actual error,
+		// which is in the container's log.
+		if crash := s.crashingPod(map[string]string{"app": name}); crash != "" {
+			return fmt.Errorf("%s is crash-looping:\n%s", name, crash)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("deployment %s not available within %s", name, Medium)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+// crashingPod returns a diagnostic for the first pod stuck restarting, or "".
+func (s *Suite) crashingPod(selector map[string]string) string {
+	var pods corev1.PodList
+	if err := s.K8s.Client.List(s.Ctx, &pods,
+		client.InNamespace(s.Namespace), client.MatchingLabels(selector)); err != nil {
+		return ""
+	}
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		for _, cs := range p.Status.ContainerStatuses {
+			waiting := cs.State.Waiting
+			if waiting == nil || waiting.Reason != "CrashLoopBackOff" {
+				continue
+			}
+			logs := s.podLogs(p.Name, cs.Name)
+			return fmt.Sprintf("pod %s container %s: %s (restarts=%d)\n%s",
+				p.Name, cs.Name, waiting.Reason, cs.RestartCount, logs)
+		}
+	}
+	return ""
+}
+
+func (s *Suite) podLogs(pod, container string) string {
+	tail := int64(20)
+	req := s.K8s.Clientset.CoreV1().Pods(s.Namespace).GetLogs(pod, &corev1.PodLogOptions{
+		Container: container,
+		Previous:  true,
+		TailLines: &tail,
+	})
+	rc, err := req.Stream(s.Ctx)
+	if err != nil {
+		return fmt.Sprintf("  <logs unavailable: %v>", err)
+	}
+	defer rc.Close()
+	b, _ := io.ReadAll(rc)
+	return string(b)
+}
+
+func (s *Suite) waitTargetsUp(names []string) error {
+	deadline := time.Now().Add(Medium)
+	for {
+		targets, err := s.GnmiGen.Targets()
+		if err == nil {
+			missing := ""
+			for _, n := range names {
+				t, ok := targets[n]
+				if !ok {
+					missing = n + " not registered"
+					break
+				}
+				if t.Status != "up" {
+					missing = n + " is " + t.Status
+					break
+				}
+			}
+			if missing == "" {
+				logf("suite %s: simulated targets %v are up", s.Name, names)
+				return nil
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("simulated targets not up: %s", missing)
+			}
+		} else if time.Now().After(deadline) {
+			return fmt.Errorf("gnmi-gen API not answering: %w", err)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func (s *Suite) applyBaseline(path string) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	_, err = s.K8s.applyYAML(string(b), nil)
+	return err
+}
+
+// TargetAddress is the dial address of simulated target n, 0-based.
+func (s *Suite) TargetAddress(n int) string {
+	return GnmiGenAddress(s.Namespace, n)
+}
+
+// Dump writes a diagnostic bundle for the suite namespace.
+func (s *Suite) Dump(w io.Writer) {
+	fmt.Fprintf(w, "\n===== diagnostics for %s (namespace %s) =====\n", s.Name, s.Namespace)
+	if s.K8s == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var pods corev1.PodList
+	if err := s.K8s.Client.List(ctx, &pods, client.InNamespace(s.Namespace)); err == nil {
+		fmt.Fprintf(w, "\n-- pods --\n")
+		for _, p := range pods.Items {
+			restarts := int32(0)
+			for _, cs := range p.Status.ContainerStatuses {
+				restarts += cs.RestartCount
+			}
+			fmt.Fprintf(w, "  %-40s %-10s restarts=%d\n", p.Name, p.Status.Phase, restarts)
+		}
+	}
+
+	if s.GnmiGen != nil {
+		fmt.Fprintf(w, "\n-- gnmi-gen targets --\n")
+		if targets, err := s.GnmiGen.Targets(); err == nil {
+			for name, t := range targets {
+				subs, _ := s.GnmiGen.Subscriptions(name)
+				fmt.Fprintf(w, "  %-12s status=%-10s clients=%d paths=%d\n", name, t.Status, len(subs), t.PathCount)
+				for _, sub := range subs {
+					fmt.Fprintf(w, "      mode=%s interval=%s notifications=%d paths=%v\n",
+						sub.Mode, sub.EffectiveSampleInterval, sub.NotificationsSent, sub.Paths)
+				}
+			}
+		} else {
+			fmt.Fprintf(w, "  unavailable: %v\n", err)
+		}
+	}
+	fmt.Fprintf(w, "\nRe-run with KEEP_NS=1 to inspect the namespace live.\n")
+	fmt.Fprintf(w, "===== end diagnostics =====\n\n")
+}
+
+// RequireGnmiGen skips a test when no simulator is present.
+func (s *Suite) RequireGnmiGen(t *testing.T) {
+	t.Helper()
+	if s.GnmiGen == nil {
+		t.Skip("test requires gnmi-gen")
+	}
+}
+
+// namespaceFor derives a suite's namespace from its numeric prefix, so
+// "003-targets" runs in gnmic-it-003 and suites never collide.
+func namespaceFor(suiteName string) string {
+	prefix := suiteName
+	if i := strings.IndexByte(suiteName, '-'); i > 0 {
+		prefix = suiteName[:i]
+	}
+	return "gnmic-it-" + prefix
+}
+
+func logf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "[harness] "+format+"\n", args...)
+}

--- a/test/integration/harness/wait.go
+++ b/test/integration/harness/wait.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package harness
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// Timeout tiers. Pick by what is being waited on rather than by guessing a
+// duration: Short for API-level effects, Medium for config reaching pods and
+// streams appearing, Long for StatefulSet rollouts and certificate issuance.
+//
+// IT_TIMEOUT_SCALE multiplies all three, for slow CI runners.
+var (
+	Short  = scaled(30 * time.Second)
+	Medium = scaled(2 * time.Minute)
+	Long   = scaled(5 * time.Minute)
+)
+
+// DefaultInterval is the poll interval used by the WaitX helpers.
+const DefaultInterval = 500 * time.Millisecond
+
+func scaled(d time.Duration) time.Duration {
+	s := os.Getenv("IT_TIMEOUT_SCALE")
+	if s == "" {
+		return d
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil || f <= 0 {
+		return d
+	}
+	return time.Duration(float64(d) * f)
+}
+
+// WaitFor polls fn until it reports true, or fails the test.
+//
+// fn returns the current observation alongside the verdict; that observation is
+// what gets reported on timeout, which is the difference between a failure you
+// can diagnose and one you have to reproduce.
+func WaitFor(t *testing.T, timeout, interval time.Duration, desc string, fn func() (bool, string)) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for {
+		ok, observed := fn()
+		if ok {
+			return
+		}
+		last = observed
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(interval)
+	}
+	t.Fatalf("timed out after %s waiting for %s; last observed: %s", timeout, desc, last)
+}
+
+// Wait is WaitFor with the default interval.
+func Wait(t *testing.T, timeout time.Duration, desc string, fn func() (bool, string)) {
+	t.Helper()
+	WaitFor(t, timeout, DefaultInterval, desc, fn)
+}
+
+// WaitInt polls until fn returns want.
+func WaitInt(t *testing.T, timeout time.Duration, desc string, want int, fn func() int) {
+	t.Helper()
+	Wait(t, timeout, desc, func() (bool, string) {
+		got := fn()
+		return got == want, "want " + strconv.Itoa(want) + ", got " + strconv.Itoa(got)
+	})
+}
+
+// Consistently asserts fn stays true for the whole duration.
+//
+// As important as WaitFor: plenty of operator bugs settle correctly and then
+// oscillate, and a single-shot check cannot tell the two apart.
+func Consistently(t *testing.T, duration, interval time.Duration, desc string, fn func() (bool, string)) {
+	t.Helper()
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		if ok, observed := fn(); !ok {
+			t.Fatalf("%s did not hold: %s", desc, observed)
+		}
+		time.Sleep(interval)
+	}
+}

--- a/test/integration/suite/000-spike/fixtures/baseline.yaml
+++ b/test/integration/suite/000-spike/fixtures/baseline.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sim-credentials
+stringData:
+  username: gnmic
+  password: gnmic
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: TargetProfile
+metadata:
+  name: default
+spec:
+  credentialsRef: sim-credentials
+  encoding: JSON_IETF
+  timeout: 10s
+  # An empty tls block means TLS with verification skipped, which matches
+  # gnmi-gen's self-signed listeners.
+  tls: {}
+  retryTimer: 2s
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: spike
+spec:
+  image: {{ .GnmicImage }}
+  replicas: 1
+  api:
+    restPort: 7890
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: if-counters
+  labels:
+    suite: spike
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 1s
+  encoding: JSON_IETF
+  paths:
+    - /interface/statistics/in-octets
+---
+# A pipeline is rejected without an output. A file output keeps the spike
+# focused on collection rather than on an output's own plumbing.
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: sink
+  labels:
+    suite: spike
+spec:
+  type: file
+  config:
+    filename: /tmp/spike-output.json
+    format: event
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: leaf1
+  labels:
+    suite: spike
+spec:
+  address: {{ .GnmiGenHost }}:57400
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: leaf2
+  labels:
+    suite: spike
+spec:
+  address: {{ .GnmiGenHost }}:57401
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: spike
+spec:
+  clusterRef: spike
+  enabled: true
+  targetSelectors:
+    - matchLabels:
+        suite: spike
+  subscriptionSelectors:
+    - matchLabels:
+        suite: spike
+  outputs:
+    outputSelectors:
+      - matchLabels:
+          suite: spike

--- a/test/integration/suite/000-spike/gnmi-gen.yaml
+++ b/test/integration/suite/000-spike/gnmi-gen.yaml
@@ -1,0 +1,54 @@
+global:
+  seed: 42
+  shutdown_timeout: 5s
+
+api:
+  listen: 0.0.0.0:8080
+
+data_profiles:
+  interface_counter:
+    type: uint64
+    update_frequency: 1s
+    random:
+      distribution: counter
+      min: 100000
+      max: 900000
+      step_min: 100
+      step_max: 10000
+
+  cpu_utilization:
+    type: uint64
+    update_frequency: 2s
+    random:
+      distribution: uniform
+      min: 5
+      max: 95
+
+  system_name:
+    type: string
+    update_frequency: 10s
+    random:
+      value: leaf-{{.index}}
+
+servers:
+  - name: leaf{{.index}}
+    expand:
+      index:
+        start: 1
+        end: 2
+      listen:
+        host: 0.0.0.0
+        port_start: 57400
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics
+        profile: interface_counter
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /platform/control/process
+        profile: cpu_utilization
+      - path: /system/name
+        profile: system_name

--- a/test/integration/suite/000-spike/spike_test.go
+++ b/test/integration/suite/000-spike/spike_test.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+// Package spike is the Phase 0 vertical slice for the integration suite.
+//
+// It exists to prove the assumptions the rest of the suites are built on,
+// before thirteen suites depend on them:
+//
+//   - gnmi-gen runs in-cluster from a ConfigMap and answers its REST API
+//     through a port-forward;
+//   - a headless Service lets collector pods dial any simulated target port
+//     without that port being enumerated on the Service;
+//   - the operator reconciles a Cluster, Pipeline, Target and Subscription into
+//     collectors that actually establish gNMI streams;
+//   - a suite namespace tears down cleanly, repeatably.
+//
+// It is not a feature test. Once 001-cluster and 003-targets exist, everything
+// here is covered better elsewhere and this package can be deleted.
+package spike
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/gnmic/operator/test/integration/harness"
+)
+
+var s *harness.Suite
+
+const (
+	clusterName = "spike"
+	leaf1       = "leaf1"
+	leaf2       = "leaf2"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(harness.RunSuite(m, harness.Options{
+		Name:           "000-spike",
+		RequireTargets: []string{leaf1, leaf2},
+		Baseline:       []string{"fixtures/baseline.yaml"},
+	}, &s))
+}
+
+// TestSpike000_SimulatorIsUp checks the device side alone, so a failure in the
+// simulator is not mistaken for a failure in the operator.
+func TestSpike000_SimulatorIsUp(t *testing.T) {
+	targets, err := s.GnmiGen.Targets()
+	if err != nil {
+		t.Fatalf("gnmi-gen API unreachable: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("want 2 simulated targets, got %d: %v", len(targets), targets)
+	}
+	for _, name := range []string{leaf1, leaf2} {
+		tgt, ok := targets[name]
+		if !ok {
+			t.Fatalf("simulated target %s missing", name)
+		}
+		if tgt.Status != "up" {
+			t.Errorf("simulated target %s is %s, want up", name, tgt.Status)
+		}
+		if tgt.PathCount == 0 {
+			t.Errorf("simulated target %s serves no paths", name)
+		}
+	}
+}
+
+// TestSpike001_OperatorBuildsClusterObjects checks the operator turned the
+// Cluster CR into the objects it owns.
+func TestSpike001_OperatorBuildsClusterObjects(t *testing.T) {
+	k := s.K8s
+
+	sts := &appsv1.StatefulSet{}
+	k.WaitExists(t, harness.StatefulSetName(clusterName), sts)
+
+	if got := *sts.Spec.Replicas; got != 1 {
+		t.Errorf("StatefulSet replicas: want 1, got %d", got)
+	}
+	if got := sts.Spec.ServiceName; got != harness.HeadlessServiceName(clusterName) {
+		t.Errorf("StatefulSet serviceName: want %s, got %s", harness.HeadlessServiceName(clusterName), got)
+	}
+
+	// The headless Service and the rendered config both have to exist before
+	// any collector can start.
+	k.Service(t, harness.HeadlessServiceName(clusterName))
+	cm := k.ConfigMap(t, harness.ConfigMapName(clusterName))
+	if len(cm.Data) == 0 {
+		t.Error("cluster ConfigMap is empty")
+	}
+}
+
+// TestSpike002_ClusterBecomesReady checks the Cluster reports Ready and that
+// its status counters agree with what was applied.
+func TestSpike002_ClusterBecomesReady(t *testing.T) {
+	harness.WaitClusterReady(t, s.K8s, clusterName)
+	harness.WaitClusterCounts(t, s.K8s, clusterName, harness.ClusterCounts{
+		ReadyReplicas:      harness.I32(1),
+		PipelinesCount:     harness.I32(1),
+		TargetsCount:       harness.I32(2),
+		SubscriptionsCount: harness.I32(1),
+		OutputsCount:       harness.I32(1),
+		UnassignedTargets:  harness.I32(0),
+	})
+}
+
+// TestSpike003_TargetsCollectedExactlyOnce is the load-bearing assertion. It
+// proves collectors resolved the headless Service, dialed a port that is not
+// declared on it, authenticated, and opened exactly one stream each.
+func TestSpike003_TargetsCollectedExactlyOnce(t *testing.T) {
+	// One subscription in the baseline, so one collector means one stream.
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+	// Held over a window, because a single sample cannot distinguish a settled
+	// placement from one that is still flapping.
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 15*time.Second, 1, leaf1, leaf2)
+}
+
+// TestSpike004_SubscriptionMatchesTheCR checks the wire-level subscription
+// reflects the Subscription CR rather than a default.
+func TestSpike004_SubscriptionMatchesTheCR(t *testing.T) {
+	subs, err := s.GnmiGen.Subscriptions(leaf1)
+	if err != nil {
+		t.Fatalf("reading subscriptions: %v", err)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("want 1 stream on %s, got %d", leaf1, len(subs))
+	}
+	sub := subs[0]
+	if sub.Mode != "STREAM" {
+		t.Errorf("subscription mode: want STREAM, got %s", sub.Mode)
+	}
+	if len(sub.Entries) != 1 {
+		t.Fatalf("want 1 subscription entry, got %d", len(sub.Entries))
+	}
+	entry := sub.Entries[0]
+	if entry.Mode != "SAMPLE" {
+		t.Errorf("entry mode: want SAMPLE, got %s", entry.Mode)
+	}
+	if entry.SampleInterval != "1s" {
+		t.Errorf("sample interval: want 1s, got %s", entry.SampleInterval)
+	}
+	s.GnmiGen.WaitPathPresent(t, leaf1, "/interface/statistics/in-octets")
+}
+
+// TestSpike005_DataFlows checks streams are carrying notifications, not merely
+// open. An established-but-silent stream is a real failure mode.
+func TestSpike005_DataFlows(t *testing.T) {
+	s.GnmiGen.WaitNotificationsAdvance(t, leaf1)
+	s.GnmiGen.WaitNotificationsAdvance(t, leaf2)
+}
+
+// TestSpike006_TargetStatusReportsPlacement checks the operator writes back
+// what the collectors report, which is how every later suite reads placement.
+func TestSpike006_TargetStatusReportsPlacement(t *testing.T) {
+	for _, name := range []string{leaf1, leaf2} {
+		harness.WaitTargetState(t, s.K8s, name, "READY")
+
+		tgt := s.K8s.Target(t, name)
+		state, ok := tgt.Status.ClusterStates[clusterName]
+		if !ok {
+			t.Fatalf("Target %s has no state for cluster %s", name, clusterName)
+		}
+		if state.Pod == "" {
+			t.Errorf("Target %s names no owning pod", name)
+		}
+		if state.ConnectionState != "READY" {
+			t.Errorf("Target %s connection state: want READY, got %s", name, state.ConnectionState)
+		}
+	}
+}
+
+// TestSpike007_NoPanics checks the collector logs are clean. Cheap, and it
+// catches crashes that a status-only assertion would sail past.
+func TestSpike007_NoPanics(t *testing.T) {
+	pods := s.K8s.ClusterPods(t, clusterName)
+	if len(pods) == 0 {
+		t.Fatal("no collector pods found")
+	}
+	for _, p := range pods {
+		harness.AssertNoPanics(t, s.K8s.Logs(t, p.Name, 10*time.Minute))
+	}
+}

--- a/test/integration/suite/001-cluster/cluster_test.go
+++ b/test/integration/suite/001-cluster/cluster_test.go
@@ -1,0 +1,414 @@
+//go:build integration
+
+// Package cluster covers the Cluster CR: the objects the operator builds from
+// it, the status it reports, scaling, and garbage collection.
+//
+// It deliberately does not cover what the collectors collect. Pipelines appear
+// only where a test needs a cluster to be doing something; target behavior
+// belongs to 003-targets and placement to 008-distribution.
+//
+// Each test creates its own cluster rather than sharing one, because the
+// cluster is the object under test. Resources are tagged per test so a
+// pipeline never selects another test's targets.
+package cluster
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/gnmic/operator/test/integration/harness"
+)
+
+var s *harness.Suite
+
+const (
+	defaultRestPort = 7890
+	gnmicConfigPath = "/etc/gnmic/config.yaml"
+	collectorCtr    = "gnmic"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(harness.RunSuite(m, harness.Options{
+		Name:           "001-cluster",
+		RequireTargets: []string{"leaf1", "leaf2", "spine1"},
+		Baseline:       []string{"fixtures/baseline.yaml"},
+	}, &s))
+}
+
+// newCluster applies a Cluster and waits for it to report Ready. The name is
+// per-test so tests never contend for one.
+func newCluster(t *testing.T, name string, replicas int, restPort, gnmiPort int) {
+	t.Helper()
+	s.K8s.ApplyFile(t, "fixtures/cluster.yaml", map[string]any{
+		"Name":     name,
+		"Image":    harness.GnmicImage(),
+		"Replicas": replicas,
+		"RestPort": restPort,
+		"GnmiPort": gnmiPort,
+	})
+	harness.WaitClusterReady(t, s.K8s, name)
+}
+
+// TestCluster001_CreatesStatefulSet checks a minimal Cluster produces a
+// correctly shaped StatefulSet.
+func TestCluster001_CreatesStatefulSet(t *testing.T) {
+	const name = "sts"
+	newCluster(t, name, 1, defaultRestPort, 0)
+
+	sts := &appsv1.StatefulSet{}
+	s.K8s.WaitExists(t, harness.StatefulSetName(name), sts)
+
+	if got := *sts.Spec.Replicas; got != 1 {
+		t.Errorf("replicas: want 1, got %d", got)
+	}
+	harness.AssertOwnedBy(t, sts, "Cluster", name)
+
+	ctr := containerNamed(t, sts, collectorCtr)
+	if ctr.Image != harness.GnmicImage() {
+		t.Errorf("container image: want %s, got %s", harness.GnmicImage(), ctr.Image)
+	}
+	if !argsContain(ctr.Command, "--config", gnmicConfigPath) {
+		t.Errorf("container command does not point at %s: %v", gnmicConfigPath, ctr.Command)
+	}
+
+	labels := sts.Spec.Template.Labels
+	if got := labels[harness.LabelClusterName]; got != name {
+		t.Errorf("pod label %s: want %s, got %q", harness.LabelClusterName, name, got)
+	}
+	if got := labels["app.kubernetes.io/managed-by"]; got != harness.ValueManagedBy {
+		t.Errorf("pod label managed-by: want %s, got %q", harness.ValueManagedBy, got)
+	}
+
+	s.K8s.WaitReadyPods(t, name, 1, harness.Long)
+}
+
+// TestCluster002_HeadlessServiceExposesAPI checks the API Service is headless
+// and carries the configured ports.
+//
+// Headless is asserted explicitly rather than incidentally: the operator
+// addresses individual pods by DNS to apply config, which only works without a
+// cluster IP.
+func TestCluster002_HeadlessServiceExposesAPI(t *testing.T) {
+	newCluster(t, "svca", 1, defaultRestPort, 0)
+	newCluster(t, "svcb", 1, 7891, 57400)
+
+	svcA := s.K8s.Service(t, harness.HeadlessServiceName("svca"))
+	if svcA.Spec.ClusterIP != corev1.ClusterIPNone {
+		t.Errorf("service gnmic-svca is not headless: clusterIP=%q", svcA.Spec.ClusterIP)
+	}
+	if got := svcA.Labels[harness.LabelServiceType]; got != harness.ValueServiceTypeHeadless {
+		t.Errorf("service-type label: want %s, got %q", harness.ValueServiceTypeHeadless, got)
+	}
+	if got := svcA.Spec.Selector[harness.LabelClusterName]; got != "svca" {
+		t.Errorf("service selector: want cluster=svca, got %q", got)
+	}
+	assertPort(t, svcA, defaultRestPort)
+
+	svcB := s.K8s.Service(t, harness.HeadlessServiceName("svcb"))
+	if svcB.Spec.ClusterIP != corev1.ClusterIPNone {
+		t.Errorf("service gnmic-svcb is not headless: clusterIP=%q", svcB.Spec.ClusterIP)
+	}
+	assertPort(t, svcB, 7891)
+	assertPort(t, svcB, 57400)
+
+	// The port is only proven usable by talking to it.
+	pods := s.K8s.WaitReadyPods(t, "svca", 1, harness.Long)
+	get := s.K8s.CollectorAPI(t, pods[0].Name, defaultRestPort)
+	harness.Wait(t, harness.Short, "collector REST API to answer", func() (bool, string) {
+		code, body := get("/api/v1/targets")
+		if code == 200 {
+			return true, ""
+		}
+		return false, fmt.Sprintf("status %d: %s", code, truncate(body))
+	})
+}
+
+// TestCluster003_BootstrapConfigMapIsMounted checks the rendered config reaches
+// the pods at the path the collector reads.
+func TestCluster003_BootstrapConfigMapIsMounted(t *testing.T) {
+	const name = "cfg"
+	newCluster(t, name, 1, defaultRestPort, 0)
+
+	cm := s.K8s.ConfigMap(t, harness.ConfigMapName(name))
+	harness.AssertOwnedBy(t, cm, "Cluster", name)
+
+	content, ok := cm.Data["config.yaml"]
+	if !ok {
+		t.Fatalf("ConfigMap has no config.yaml key; keys are %v", keysOf(cm.Data))
+	}
+
+	var parsed struct {
+		APIServer struct {
+			Address string `json:"address"`
+		} `json:"api-server"`
+	}
+	if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("config.yaml does not parse: %v\n%s", err, content)
+	}
+	if want := fmt.Sprintf(":%d", defaultRestPort); parsed.APIServer.Address != want {
+		t.Errorf("api-server address: want %s, got %q", want, parsed.APIServer.Address)
+	}
+
+	// What the pod has on disk, rather than what the ConfigMap claims.
+	pods := s.K8s.WaitReadyPods(t, name, 1, harness.Long)
+	onDisk := s.K8s.Exec(t, pods[0].Name, collectorCtr, "cat", gnmicConfigPath)
+	if strings.TrimSpace(onDisk) != strings.TrimSpace(content) {
+		t.Errorf("file at %s differs from the ConfigMap\n--- pod ---\n%s\n--- configmap ---\n%s",
+			gnmicConfigPath, onDisk, content)
+	}
+}
+
+// TestCluster004_ImageChangeRollsStatefulSet checks a spec.image edit triggers
+// a rollout and converges.
+func TestCluster004_ImageChangeRollsStatefulSet(t *testing.T) {
+	const name = "img"
+	newCluster(t, name, 1, defaultRestPort, 0)
+
+	before := &appsv1.StatefulSet{}
+	s.K8s.WaitExists(t, harness.StatefulSetName(name), before)
+	genBefore := before.Generation
+
+	newImage := altGnmicImage()
+	s.K8s.Patch(t, s.K8s.Cluster(t, name), fmt.Sprintf(`{"spec":{"image":%q}}`, newImage))
+
+	harness.Wait(t, harness.Medium, "StatefulSet to pick up the new image", func() (bool, string) {
+		sts := s.K8s.StatefulSet(t, harness.StatefulSetName(name))
+		ctr := containerNamed(t, sts, collectorCtr)
+		if ctr.Image != newImage {
+			return false, "image is still " + ctr.Image
+		}
+		if sts.Generation <= genBefore {
+			return false, fmt.Sprintf("generation did not advance past %d", genBefore)
+		}
+		return true, ""
+	})
+
+	// Waiting for "one ready pod" is not enough: during a single-replica
+	// rollout the old pod can still be the ready one. Wait for the ready pod to
+	// be running the new image.
+	harness.Wait(t, harness.Long, "the ready pod to be running the new image", func() (bool, string) {
+		for _, p := range s.K8s.ClusterPods(t, name) {
+			if p.DeletionTimestamp != nil {
+				continue
+			}
+			img := p.Spec.Containers[0].Image
+			if img == newImage {
+				return true, ""
+			}
+			return false, fmt.Sprintf("pod %s still runs %s", p.Name, img)
+		}
+		return false, "no pods"
+	})
+	s.K8s.WaitReadyPods(t, name, 1, harness.Long)
+	harness.WaitClusterReady(t, s.K8s, name)
+	harness.WaitClusterCounts(t, s.K8s, name, harness.ClusterCounts{ReadyReplicas: harness.I32(1)})
+}
+
+// TestCluster005_ScalingChangesReplicaCount checks replica edits produce and
+// remove pods, and that status follows in both directions.
+func TestCluster005_ScalingChangesReplicaCount(t *testing.T) {
+	const name = "scale"
+	newCluster(t, name, 1, defaultRestPort, 0)
+	s.K8s.WaitReadyPods(t, name, 1, harness.Long)
+
+	s.K8s.Patch(t, s.K8s.Cluster(t, name), `{"spec":{"replicas":3}}`)
+	harness.Wait(t, harness.Medium, "StatefulSet to request 3 replicas", func() (bool, string) {
+		sts := s.K8s.StatefulSet(t, harness.StatefulSetName(name))
+		return *sts.Spec.Replicas == 3, fmt.Sprintf("spec.replicas=%d", *sts.Spec.Replicas)
+	})
+	s.K8s.WaitReadyPods(t, name, 3, harness.Long)
+	harness.WaitClusterCounts(t, s.K8s, name, harness.ClusterCounts{ReadyReplicas: harness.I32(3)})
+	harness.WaitClusterReady(t, s.K8s, name)
+	assertStaysReady(t, name)
+
+	s.K8s.Patch(t, s.K8s.Cluster(t, name), `{"spec":{"replicas":1}}`)
+	s.K8s.WaitPodGone(t, harness.PodName(name, 1))
+	s.K8s.WaitPodGone(t, harness.PodName(name, 2))
+	s.K8s.WaitReadyPods(t, name, 1, harness.Long)
+	harness.WaitClusterCounts(t, s.K8s, name, harness.ClusterCounts{ReadyReplicas: harness.I32(1)})
+	harness.WaitClusterReady(t, s.K8s, name)
+	assertStaysReady(t, name)
+}
+
+// TestCluster006_ConfigAppliedWithoutRestart checks that adding collection work
+// to a running cluster reconfigures pods over the REST API instead of rolling
+// them.
+//
+// This is the claim every dynamic-edit test in the suite rests on, so it is
+// asserted here in its simplest form.
+func TestCluster006_ConfigAppliedWithoutRestart(t *testing.T) {
+	const name = "dyn"
+	newCluster(t, name, 1, defaultRestPort, 0)
+	s.K8s.WaitReadyPods(t, name, 1, harness.Long)
+
+	restartsBefore := s.K8s.RestartCounts(t, name)
+	genBefore := s.K8s.StatefulSet(t, harness.StatefulSetName(name)).Generation
+
+	s.K8s.ApplyFile(t, "fixtures/collection.yaml", map[string]any{
+		"Tag":     name,
+		"Cluster": name,
+	})
+
+	s.GnmiGen.WaitStreams(t, "leaf1", 1)
+	harness.WaitConfigApplied(t, s.K8s, name)
+
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, name))
+	if genAfter := s.K8s.StatefulSet(t, harness.StatefulSetName(name)).Generation; genAfter != genBefore {
+		t.Errorf("StatefulSet generation changed: %d -> %d; the config was applied by rolling pods", genBefore, genAfter)
+	}
+}
+
+// TestCluster007_StatusCountersReflectResources checks the counters describe
+// what the cluster is actually running, and that they follow a deletion.
+//
+// The counters are paired with a device-side check, because status on its own
+// is only the operator agreeing with itself.
+func TestCluster007_StatusCountersReflectResources(t *testing.T) {
+	const name = "counts"
+	newCluster(t, name, 1, defaultRestPort, 0)
+
+	s.K8s.ApplyFile(t, "fixtures/counters.yaml", map[string]any{
+		"Tag":     name,
+		"Cluster": name,
+	})
+
+	harness.WaitClusterCounts(t, s.K8s, name, harness.ClusterCounts{
+		PipelinesCount:     harness.I32(1),
+		TargetsCount:       harness.I32(2),
+		SubscriptionsCount: harness.I32(3),
+		OutputsCount:       harness.I32(1),
+		InputsCount:        harness.I32(0),
+		UnassignedTargets:  harness.I32(0),
+	})
+	// Three subscriptions are bound here, so one collector opens three streams
+	// per target.
+	s.GnmiGen.AssertCollectedOnce(t, 3, "leaf1", "leaf2")
+
+	s.K8s.Delete(t, s.K8s.Target(t, name+"-leaf2"))
+
+	harness.WaitClusterCounts(t, s.K8s, name, harness.ClusterCounts{TargetsCount: harness.I32(1)})
+	s.GnmiGen.WaitStreams(t, "leaf2", 0)
+	s.GnmiGen.WaitStreams(t, "leaf1", 3)
+}
+
+// TestCluster008_DeletingClusterGarbageCollects checks owner references are set
+// correctly, so deleting a Cluster leaves nothing behind.
+//
+// The device-side check matters: an object can be deleted while its process
+// keeps streaming for a while, so "the StatefulSet is gone" does not by itself
+// prove collection stopped.
+func TestCluster008_DeletingClusterGarbageCollects(t *testing.T) {
+	const name = "gc"
+	newCluster(t, name, 1, defaultRestPort, 0)
+
+	s.K8s.ApplyFile(t, "fixtures/prom.yaml", map[string]any{
+		"Tag":     name,
+		"Cluster": name,
+	})
+	s.GnmiGen.WaitStreams(t, "leaf1", 1)
+
+	promService := harness.PromServiceName(name, name, name+"-prom")
+	s.K8s.WaitExists(t, promService, &corev1.Service{})
+
+	s.K8s.Delete(t, s.K8s.Cluster(t, name))
+
+	s.K8s.WaitAbsent(t, harness.StatefulSetName(name), &appsv1.StatefulSet{})
+	s.K8s.WaitAbsent(t, harness.HeadlessServiceName(name), &corev1.Service{})
+	s.K8s.WaitAbsent(t, harness.ConfigMapName(name), &corev1.ConfigMap{})
+	s.K8s.WaitAbsent(t, promService, &corev1.Service{})
+
+	harness.Wait(t, harness.Medium, "collector pods to be gone", func() (bool, string) {
+		pods := s.K8s.ClusterPods(t, name)
+		return len(pods) == 0, fmt.Sprintf("%d pod(s) remain", len(pods))
+	})
+	s.GnmiGen.WaitStreams(t, "leaf1", 0)
+
+	// The Pipeline outlives the Cluster it referenced; it just has nowhere to run.
+	if p := s.K8s.Pipeline(t, name); p.Name == "" {
+		t.Error("Pipeline was garbage-collected along with the Cluster")
+	}
+}
+
+// --- helpers -------------------------------------------------------------
+
+func assertStaysReady(t *testing.T, name string) {
+	t.Helper()
+	harness.Consistently(t, 10*time.Second, time.Second, "Cluster "+name+" staying Ready", func() (bool, string) {
+		c := s.K8s.Cluster(t, name)
+		for _, cond := range c.Status.Conditions {
+			if cond.Type == harness.CondReady {
+				return cond.Status == metav1.ConditionTrue,
+					fmt.Sprintf("Ready=%s reason=%s", cond.Status, cond.Reason)
+			}
+		}
+		return false, "Ready condition absent"
+	})
+}
+
+func containerNamed(t *testing.T, sts *appsv1.StatefulSet, name string) corev1.Container {
+	t.Helper()
+	var names []string
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		if c.Name == name {
+			return c
+		}
+		names = append(names, c.Name)
+	}
+	t.Fatalf("no container named %s in %s; containers are %v", name, sts.Name, names)
+	return corev1.Container{}
+}
+
+func argsContain(args []string, flag, value string) bool {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) && args[i+1] == value {
+			return true
+		}
+		if a == flag+"="+value {
+			return true
+		}
+	}
+	return false
+}
+
+func assertPort(t *testing.T, svc *corev1.Service, want int32) {
+	t.Helper()
+	var have []int32
+	for _, p := range svc.Spec.Ports {
+		if p.Port == want {
+			return
+		}
+		have = append(have, p.Port)
+	}
+	t.Errorf("service %s has no port %d; ports are %v", svc.Name, want, have)
+}
+
+// altGnmicImage is a second pinned tag, used to prove a rollout happened.
+func altGnmicImage() string {
+	if v := os.Getenv("GNMIC_IMAGE_ALT"); v != "" {
+		return v
+	}
+	return "ghcr.io/openconfig/gnmic:0.44.0-amd64"
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func truncate(s string) string {
+	if len(s) > 200 {
+		return s[:200] + "..."
+	}
+	return s
+}

--- a/test/integration/suite/001-cluster/fixtures/baseline.yaml
+++ b/test/integration/suite/001-cluster/fixtures/baseline.yaml
@@ -1,0 +1,24 @@
+# Baseline for 001-cluster: credentials and a target profile only.
+#
+# There is deliberately no Cluster here. Clusters are the thing under test in
+# this suite, so each test creates and destroys its own.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sim-credentials
+stringData:
+  username: gnmic
+  password: gnmic
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: TargetProfile
+metadata:
+  name: default
+spec:
+  credentialsRef: sim-credentials
+  encoding: JSON_IETF
+  timeout: 10s
+  # An empty tls block means TLS with verification skipped, matching gnmi-gen's
+  # self-signed listeners.
+  tls: {}
+  retryTimer: 2s

--- a/test/integration/suite/001-cluster/fixtures/cluster.yaml
+++ b/test/integration/suite/001-cluster/fixtures/cluster.yaml
@@ -1,0 +1,12 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: {{ .Name }}
+spec:
+  image: {{ .Image }}
+  replicas: {{ .Replicas }}
+  api:
+    restPort: {{ .RestPort }}
+{{- if .GnmiPort }}
+    gnmiPort: {{ .GnmiPort }}
+{{- end }}

--- a/test/integration/suite/001-cluster/fixtures/collection.yaml
+++ b/test/integration/suite/001-cluster/fixtures/collection.yaml
@@ -1,0 +1,56 @@
+# A minimal amount of collection work bound to one cluster.
+#
+# Every object is labelled with .Tag and the pipeline selects on that label, so
+# tests sharing this namespace never pick up each other's resources.
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: {{ .Tag }}-leaf1
+  labels:
+    tag: {{ .Tag }}
+spec:
+  address: {{ .GnmiGenHost }}:57400
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .Tag }}-if
+  labels:
+    tag: {{ .Tag }}
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 1s
+  encoding: JSON_IETF
+  paths:
+    - /interface/statistics/in-octets
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: {{ .Tag }}-sink
+  labels:
+    tag: {{ .Tag }}
+spec:
+  type: file
+  config:
+    filename: /tmp/{{ .Tag }}.json
+    format: event
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: {{ .Tag }}
+spec:
+  clusterRef: {{ .Cluster }}
+  enabled: true
+  targetSelectors:
+    - matchLabels:
+        tag: {{ .Tag }}
+  subscriptionSelectors:
+    - matchLabels:
+        tag: {{ .Tag }}
+  outputs:
+    outputSelectors:
+      - matchLabels:
+          tag: {{ .Tag }}

--- a/test/integration/suite/001-cluster/fixtures/counters.yaml
+++ b/test/integration/suite/001-cluster/fixtures/counters.yaml
@@ -1,0 +1,90 @@
+# Two targets, three subscriptions, one output: shapes the status counters
+# asserted by 001-7 so that every counter has a distinct expected value.
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: {{ .Tag }}-leaf1
+  labels:
+    tag: {{ .Tag }}
+spec:
+  address: {{ .GnmiGenHost }}:57400
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: {{ .Tag }}-leaf2
+  labels:
+    tag: {{ .Tag }}
+spec:
+  address: {{ .GnmiGenHost }}:57401
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .Tag }}-if
+  labels:
+    tag: {{ .Tag }}
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 1s
+  encoding: JSON_IETF
+  paths:
+    - /interface/statistics/in-octets
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .Tag }}-cpu
+  labels:
+    tag: {{ .Tag }}
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 2s
+  encoding: JSON_IETF
+  paths:
+    - /platform/control/process
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .Tag }}-sys
+  labels:
+    tag: {{ .Tag }}
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 10s
+  encoding: JSON_IETF
+  paths:
+    - /system/name
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: {{ .Tag }}-sink
+  labels:
+    tag: {{ .Tag }}
+spec:
+  type: file
+  config:
+    filename: /tmp/{{ .Tag }}.json
+    format: event
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: {{ .Tag }}
+spec:
+  clusterRef: {{ .Cluster }}
+  enabled: true
+  targetSelectors:
+    - matchLabels:
+        tag: {{ .Tag }}
+  subscriptionSelectors:
+    - matchLabels:
+        tag: {{ .Tag }}
+  outputs:
+    outputSelectors:
+      - matchLabels:
+          tag: {{ .Tag }}

--- a/test/integration/suite/001-cluster/fixtures/prom.yaml
+++ b/test/integration/suite/001-cluster/fixtures/prom.yaml
@@ -1,0 +1,51 @@
+# A Prometheus output, so that deleting the cluster has an output Service to
+# garbage-collect as well as the StatefulSet, Service and ConfigMap.
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: {{ .Tag }}-leaf1
+  labels:
+    tag: {{ .Tag }}
+spec:
+  address: {{ .GnmiGenHost }}:57400
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .Tag }}-if
+  labels:
+    tag: {{ .Tag }}
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 1s
+  encoding: JSON_IETF
+  paths:
+    - /interface/statistics/in-octets
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: {{ .Tag }}-prom
+  labels:
+    tag: {{ .Tag }}
+spec:
+  type: prometheus
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: {{ .Tag }}
+spec:
+  clusterRef: {{ .Cluster }}
+  enabled: true
+  targetSelectors:
+    - matchLabels:
+        tag: {{ .Tag }}
+  subscriptionSelectors:
+    - matchLabels:
+        tag: {{ .Tag }}
+  outputs:
+    outputSelectors:
+      - matchLabels:
+          tag: {{ .Tag }}

--- a/test/integration/suite/001-cluster/gnmi-gen.yaml
+++ b/test/integration/suite/001-cluster/gnmi-gen.yaml
@@ -1,0 +1,78 @@
+global:
+  seed: 42
+  shutdown_timeout: 5s
+
+api:
+  listen: 0.0.0.0:8080
+
+data_profiles:
+  interface_counter:
+    type: uint64
+    update_frequency: 1s
+    random:
+      distribution: counter
+      min: 100000
+      max: 900000
+      step_min: 100
+      step_max: 10000
+
+  cpu_utilization:
+    type: uint64
+    update_frequency: 2s
+    random:
+      distribution: uniform
+      min: 5
+      max: 95
+
+  # {{.index}} is only bound for servers created through `expand`, so the
+  # standalone spine needs a profile of its own.
+  system_name:
+    type: string
+    update_frequency: 10s
+    random:
+      value: leaf-{{.index}}
+
+  system_name_spine:
+    type: string
+    update_frequency: 10s
+    random:
+      value: spine-1
+
+servers:
+  - name: leaf{{.index}}
+    expand:
+      index:
+        start: 1
+        end: 2
+      listen:
+        host: 0.0.0.0
+        port_start: 57400
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics
+        profile: interface_counter
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /platform/control/process
+        profile: cpu_utilization
+      - path: /system/name
+        profile: system_name
+
+  - name: spine1
+    listen: 0.0.0.0:57402
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics
+        profile: interface_counter
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /platform/control/process
+        profile: cpu_utilization
+      - path: /system/name
+        profile: system_name_spine

--- a/test/integration/suite/002-pipelines/fixtures/baseline.yaml
+++ b/test/integration/suite/002-pipelines/fixtures/baseline.yaml
@@ -1,0 +1,100 @@
+# Shared props for 002-pipelines. Pipelines are created per test.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sim-credentials
+stringData:
+  username: gnmic
+  password: gnmic
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: TargetProfile
+metadata:
+  name: default
+spec:
+  credentialsRef: sim-credentials
+  encoding: JSON_IETF
+  timeout: 10s
+  tls: {}
+  retryTimer: 2s
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: c1
+spec:
+  image: {{ .GnmicImage }}
+  replicas: 1
+  api:
+    restPort: 7890
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: leaf1
+  labels:
+    vendor: gnmi-gen
+    role: leaf
+spec:
+  address: {{ .GnmiGenHost }}:57400
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: leaf2
+  labels:
+    vendor: gnmi-gen
+    role: leaf
+spec:
+  address: {{ .GnmiGenHost }}:57401
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: spine1
+  labels:
+    vendor: gnmi-gen
+    role: spine
+spec:
+  address: {{ .GnmiGenHost }}:57402
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: if-counters
+  labels:
+    group: interface_metrics
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 1s
+  encoding: JSON_IETF
+  paths:
+    - /interface/statistics/in-octets
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: system-state
+  labels:
+    group: system_state
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 2s
+  encoding: JSON_IETF
+  paths:
+    - /system/name
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: sink
+  labels:
+    type: metrics
+spec:
+  type: file
+  config:
+    filename: /tmp/002-sink.json
+    format: event

--- a/test/integration/suite/002-pipelines/fixtures/pipeline.yaml
+++ b/test/integration/suite/002-pipelines/fixtures/pipeline.yaml
@@ -1,0 +1,34 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: {{ .Name }}
+spec:
+  clusterRef: c1
+  enabled: {{ .Enabled }}
+{{- if .TargetRefs }}
+  targetRefs:
+{{- range .TargetRefs }}
+    - {{ . }}
+{{- end }}
+{{- end }}
+{{- if .TargetRole }}
+  targetSelectors:
+    - matchLabels:
+        role: {{ .TargetRole }}
+{{- end }}
+{{- if .SubGroup }}
+  subscriptionSelectors:
+    - matchLabels:
+        group: {{ .SubGroup }}
+{{- end }}
+{{- if .SubGroups }}
+  subscriptionSelectors:
+{{- range .SubGroups }}
+    - matchLabels:
+        group: {{ . }}
+{{- end }}
+{{- end }}
+  outputs:
+    outputSelectors:
+      - matchLabels:
+          type: metrics

--- a/test/integration/suite/002-pipelines/gnmi-gen.yaml
+++ b/test/integration/suite/002-pipelines/gnmi-gen.yaml
@@ -1,0 +1,60 @@
+global:
+  seed: 42
+  shutdown_timeout: 5s
+
+api:
+  listen: 0.0.0.0:8080
+
+data_profiles:
+  interface_counter:
+    type: uint64
+    update_frequency: 1s
+    random:
+      distribution: counter
+      min: 100000
+      max: 900000
+      step_min: 100
+      step_max: 10000
+
+  system_name:
+    type: string
+    update_frequency: 10s
+    random:
+      value: leaf-{{.index}}
+
+  system_name_spine:
+    type: string
+    update_frequency: 10s
+    random:
+      value: spine-1
+
+servers:
+  - name: leaf{{.index}}
+    expand:
+      index:
+        start: 1
+        end: 2
+      listen:
+        host: 0.0.0.0
+        port_start: 57400
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name
+
+  - name: spine1
+    listen: 0.0.0.0:57402
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name_spine

--- a/test/integration/suite/002-pipelines/pipelines_test.go
+++ b/test/integration/suite/002-pipelines/pipelines_test.go
@@ -1,0 +1,384 @@
+//go:build integration
+
+// Package pipelines covers Pipeline resolution: selectors, refs, label-driven
+// membership, enable/disable, isolation between pipelines, and deletion.
+package pipelines
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gnmicv1alpha1 "github.com/gnmic/operator/api/v1alpha1"
+	"github.com/gnmic/operator/test/integration/harness"
+)
+
+var s *harness.Suite
+
+const (
+	cluster = "c1"
+	leaf1   = "leaf1"
+	leaf2   = "leaf2"
+	spine1  = "spine1"
+	pathIF  = "/interface/statistics/in-octets"
+	pathSys = "/system/name"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(harness.RunSuite(m, harness.Options{
+		Name:           "002-pipelines",
+		RequireTargets: []string{leaf1, leaf2, spine1},
+		Baseline:       []string{"fixtures/baseline.yaml"},
+	}, &s))
+}
+
+func waitClusterReady(t *testing.T) {
+	t.Helper()
+	harness.WaitClusterReady(t, s.K8s, cluster)
+	s.K8s.WaitReadyPods(t, cluster, 1, harness.Long)
+}
+
+// waitIdle removes any leftover Pipelines from a prior test (cleanup is
+// best-effort and the Cluster can keep streaming until it reconciles the
+// deletion), then waits until the wire is quiet.
+func waitIdle(t *testing.T) {
+	t.Helper()
+	var list gnmicv1alpha1.PipelineList
+	if err := s.K8s.Client.List(s.Ctx, &list, client.InNamespace(s.Namespace)); err == nil {
+		for i := range list.Items {
+			p := &list.Items[i]
+			_ = s.K8s.Client.Delete(s.Ctx, p)
+		}
+	}
+	harness.Wait(t, harness.Medium, "all pipelines gone", func() (bool, string) {
+		var left gnmicv1alpha1.PipelineList
+		if err := s.K8s.Client.List(s.Ctx, &left, client.InNamespace(s.Namespace)); err != nil {
+			return false, err.Error()
+		}
+		return len(left.Items) == 0, fmt.Sprintf("%d pipeline(s) remain", len(left.Items))
+	})
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		PipelinesCount: harness.I32(0),
+		TargetsCount:   harness.I32(0),
+	})
+	harness.Wait(t, harness.Medium, "all simulated targets idle", func() (bool, string) {
+		for _, name := range []string{leaf1, leaf2, spine1} {
+			if n := s.GnmiGen.StreamCount(name); n != 0 {
+				return false, fmt.Sprintf("%s has %d streams", name, n)
+			}
+		}
+		return true, ""
+	})
+}
+
+// applyPipeline applies a Pipeline fixture. Empty optional fields must still be
+// present in vars because the renderer uses missingkey=error.
+// Cleanup is deferred to waitIdle (and suite teardown) rather than t.Cleanup,
+// so a late SSA delete cannot race the next test's Cluster reconcile.
+func applyPipeline(t *testing.T, name string, vars map[string]any) {
+	t.Helper()
+	base := map[string]any{
+		"Name":       name,
+		"Enabled":    true,
+		"TargetRefs": []string{},
+		"TargetRole": "",
+		"SubGroup":   "",
+		"SubGroups":  []string{},
+	}
+	for k, v := range vars {
+		base[k] = v
+	}
+	b, err := os.ReadFile("fixtures/pipeline.yaml")
+	if err != nil {
+		t.Fatalf("reading pipeline fixture: %v", err)
+	}
+	if _, err := s.K8s.ApplyYAMLNoCleanup(string(b), base); err != nil {
+		t.Fatalf("applying pipeline %s: %v", name, err)
+	}
+}
+
+func waitPipelineReady(t *testing.T, name string, counts harness.PipelineCounts) {
+	t.Helper()
+	harness.WaitPipelineCounts(t, s.K8s, name, counts)
+	harness.WaitPipelineCondition(t, s.K8s, name, harness.CondReady, metav1.ConditionTrue)
+	harness.WaitPipelineCondition(t, s.K8s, name, harness.CondResourcesResolved, metav1.ConditionTrue)
+}
+
+func restoreSpineRole(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		s.K8s.Patch(t, s.K8s.Target(t, spine1), `{"metadata":{"labels":{"role":"spine"}}}`)
+	})
+}
+
+func assertEstablishedStable(t *testing.T, before map[string]time.Time, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		was, now := before[name], s.GnmiGen.EstablishedAt(name)
+		if !was.IsZero() && !now.IsZero() && now.Sub(was).Abs() > time.Second {
+			t.Errorf("%s re-established: %s -> %s", name, was, now)
+		}
+	}
+}
+
+// TestPipe001_BindsTargetsBySelector checks targetSelectors resolve the match
+// set and leave non-matching targets uncollected.
+func TestPipe001_BindsTargetsBySelector(t *testing.T) {
+	waitClusterReady(t)
+	waitIdle(t)
+
+	applyPipeline(t, "by-sel", map[string]any{
+		"TargetRole": "leaf",
+		"SubGroup":   "interface_metrics",
+	})
+	waitPipelineReady(t, "by-sel", harness.PipelineCounts{
+		TargetsCount:       harness.I32(2),
+		SubscriptionsCount: harness.I32(1),
+		OutputsCount:       harness.I32(1),
+	})
+
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+	s.GnmiGen.WaitStreams(t, spine1, 0)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		TargetsCount: harness.I32(2),
+	})
+}
+
+// TestPipe002_BindsTargetsByRef checks targetRefs and additive mixing with selectors.
+func TestPipe002_BindsTargetsByRef(t *testing.T) {
+	waitClusterReady(t)
+	waitIdle(t)
+
+	applyPipeline(t, "by-ref", map[string]any{
+		"TargetRefs": []string{spine1},
+		"SubGroup":   "interface_metrics",
+	})
+	s.GnmiGen.WaitStreams(t, spine1, 1)
+	s.GnmiGen.WaitStreams(t, leaf1, 0)
+	s.GnmiGen.WaitStreams(t, leaf2, 0)
+	harness.WaitPipelineCounts(t, s.K8s, "by-ref", harness.PipelineCounts{
+		TargetsCount: harness.I32(1),
+	})
+
+	s.K8s.Patch(t, s.K8s.Pipeline(t, "by-ref"), `{
+		"spec":{
+			"targetSelectors":[{"matchLabels":{"role":"leaf"}}]
+		}
+	}`)
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2, spine1)
+	harness.WaitPipelineCounts(t, s.K8s, "by-ref", harness.PipelineCounts{
+		TargetsCount: harness.I32(3),
+	})
+}
+
+// TestPipe003_LabelAddPullsTargetIn checks membership follows Target labels.
+func TestPipe003_LabelAddPullsTargetIn(t *testing.T) {
+	waitClusterReady(t)
+	waitIdle(t)
+	restoreSpineRole(t)
+
+	applyPipeline(t, "label-add", map[string]any{
+		"TargetRole": "leaf",
+		"SubGroup":   "interface_metrics",
+	})
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+	estab := map[string]time.Time{
+		leaf1: s.GnmiGen.EstablishedAt(leaf1),
+		leaf2: s.GnmiGen.EstablishedAt(leaf2),
+	}
+
+	s.K8s.Patch(t, s.K8s.Target(t, spine1), `{"metadata":{"labels":{"role":"leaf"}}}`)
+	s.GnmiGen.WaitStreams(t, spine1, 1)
+	harness.WaitPipelineCounts(t, s.K8s, "label-add", harness.PipelineCounts{
+		TargetsCount: harness.I32(3),
+	})
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+	assertEstablishedStable(t, estab, leaf1, leaf2)
+}
+
+// TestPipe004_LabelRemoveDropsTarget checks collection stops when membership ends.
+func TestPipe004_LabelRemoveDropsTarget(t *testing.T) {
+	waitClusterReady(t)
+	waitIdle(t)
+	restoreSpineRole(t)
+
+	s.K8s.Patch(t, s.K8s.Target(t, spine1), `{"metadata":{"labels":{"role":"leaf"}}}`)
+
+	applyPipeline(t, "label-rm", map[string]any{
+		"TargetRole": "leaf",
+		"SubGroup":   "interface_metrics",
+	})
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2, spine1)
+	estab := map[string]time.Time{
+		leaf1: s.GnmiGen.EstablishedAt(leaf1),
+		leaf2: s.GnmiGen.EstablishedAt(leaf2),
+	}
+
+	s.K8s.Patch(t, s.K8s.Target(t, spine1), `{"metadata":{"labels":{"role":"spine"}}}`)
+	s.GnmiGen.WaitStreams(t, spine1, 0)
+	harness.WaitPipelineCounts(t, s.K8s, "label-rm", harness.PipelineCounts{
+		TargetsCount: harness.I32(2),
+	})
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+	assertEstablishedStable(t, estab, leaf1, leaf2)
+}
+
+// TestPipe005_SubscriptionSelectorControlsPaths checks stream count and paths
+// track bound Subscriptions.
+func TestPipe005_SubscriptionSelectorControlsPaths(t *testing.T) {
+	waitClusterReady(t)
+	waitIdle(t)
+
+	applyPipeline(t, "subs", map[string]any{
+		"TargetRole": "leaf",
+		"SubGroup":   "interface_metrics",
+	})
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+	s.GnmiGen.WaitPathPresent(t, leaf1, pathIF)
+	s.GnmiGen.WaitPathAbsent(t, leaf1, pathSys)
+
+	s.K8s.Patch(t, s.K8s.Pipeline(t, "subs"), `{
+		"spec":{
+			"subscriptionSelectors":[
+				{"matchLabels":{"group":"interface_metrics"}},
+				{"matchLabels":{"group":"system_state"}}
+			]
+		}
+	}`)
+	s.GnmiGen.WaitStreams(t, leaf1, 2)
+	s.GnmiGen.WaitStreams(t, leaf2, 2)
+	s.GnmiGen.WaitPathPresent(t, leaf1, pathIF)
+	s.GnmiGen.WaitPathPresent(t, leaf1, pathSys)
+	harness.WaitPipelineCounts(t, s.K8s, "subs", harness.PipelineCounts{
+		SubscriptionsCount: harness.I32(2),
+	})
+}
+
+// TestPipe006_DisabledCollectsNothing checks enabled:false stops work without
+// deleting bound CRs.
+func TestPipe006_DisabledCollectsNothing(t *testing.T) {
+	waitClusterReady(t)
+	waitIdle(t)
+
+	applyPipeline(t, "toggle", map[string]any{
+		"TargetRole": "leaf",
+		"SubGroup":   "interface_metrics",
+	})
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+
+	s.K8s.Patch(t, s.K8s.Pipeline(t, "toggle"), `{"spec":{"enabled":false}}`)
+	s.GnmiGen.WaitStreams(t, leaf1, 0)
+	s.GnmiGen.WaitStreams(t, leaf2, 0)
+	harness.WaitPipelineStatusString(t, s.K8s, "toggle", "Disabled")
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		TargetsCount: harness.I32(0),
+	})
+	_ = s.K8s.Target(t, leaf1)
+	_ = s.K8s.Pipeline(t, "toggle")
+
+	s.K8s.Patch(t, s.K8s.Pipeline(t, "toggle"), `{"spec":{"enabled":true}}`)
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+}
+
+// TestPipe007_TwoPipelinesStayIsolated checks pipelines on one cluster do not
+// leak resources into each other.
+func TestPipe007_TwoPipelinesStayIsolated(t *testing.T) {
+	waitClusterReady(t)
+	waitIdle(t)
+
+	applyPipeline(t, "p-leaf", map[string]any{
+		"TargetRole": "leaf",
+		"SubGroup":   "interface_metrics",
+	})
+	applyPipeline(t, "p-spine", map[string]any{
+		"TargetRole": "spine",
+		"SubGroup":   "system_state",
+	})
+
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2, spine1)
+	s.GnmiGen.WaitPathPresent(t, leaf1, pathIF)
+	s.GnmiGen.WaitPathAbsent(t, leaf1, pathSys)
+	s.GnmiGen.WaitPathPresent(t, spine1, pathSys)
+	s.GnmiGen.WaitPathAbsent(t, spine1, pathIF)
+
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		PipelinesCount: harness.I32(2),
+		TargetsCount:   harness.I32(3),
+	})
+
+	estab := map[string]time.Time{
+		leaf1: s.GnmiGen.EstablishedAt(leaf1),
+		leaf2: s.GnmiGen.EstablishedAt(leaf2),
+	}
+	s.K8s.Delete(t, s.K8s.Pipeline(t, "p-spine"))
+	s.GnmiGen.WaitStreams(t, spine1, 0)
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+	assertEstablishedStable(t, estab, leaf1, leaf2)
+}
+
+// TestPipe008_DeletingPipelineStopsCollection checks deletion removes work
+// from the pods without deleting bound CRs or restarting collectors.
+func TestPipe008_DeletingPipelineStopsCollection(t *testing.T) {
+	waitClusterReady(t)
+	waitIdle(t)
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	applyPipeline(t, "doomed", map[string]any{
+		"TargetRole": "leaf",
+		"SubGroup":   "interface_metrics",
+	})
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+
+	s.K8s.Delete(t, s.K8s.Pipeline(t, "doomed"))
+	s.GnmiGen.WaitStreams(t, leaf1, 0)
+	s.GnmiGen.WaitStreams(t, leaf2, 0)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		PipelinesCount:     harness.I32(0),
+		TargetsCount:       harness.I32(0),
+		SubscriptionsCount: harness.I32(0),
+		OutputsCount:       harness.I32(0),
+	})
+	harness.WaitClusterReady(t, s.K8s, cluster)
+
+	_ = s.K8s.Target(t, leaf1)
+	sub := &gnmicv1alpha1.Subscription{}
+	if err := s.K8s.Client.Get(s.Ctx, types.NamespacedName{Namespace: s.Namespace, Name: "if-counters"}, sub); err != nil {
+		t.Fatalf("subscription should still exist: %v", err)
+	}
+	out := &gnmicv1alpha1.Output{}
+	if err := s.K8s.Client.Get(s.Ctx, types.NamespacedName{Namespace: s.Namespace, Name: "sink"}, out); err != nil {
+		t.Fatalf("output should still exist: %v", err)
+	}
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}
+
+// TestPipe009_OverlappingPipelinesCollectOncePerCluster checks two pipelines
+// selecting the same targets do not double-connect; stream count tracks the
+// union of subscriptions.
+func TestPipe009_OverlappingPipelinesCollectOncePerCluster(t *testing.T) {
+	waitClusterReady(t)
+	waitIdle(t)
+
+	applyPipeline(t, "ov-if", map[string]any{
+		"TargetRole": "leaf",
+		"SubGroup":   "interface_metrics",
+	})
+	applyPipeline(t, "ov-sys", map[string]any{
+		"TargetRole": "leaf",
+		"SubGroup":   "system_state",
+	})
+
+	// One stream per Subscription, not one per Pipeline.
+	s.GnmiGen.AssertCollectedOnce(t, 2, leaf1, leaf2)
+	s.GnmiGen.WaitPathPresent(t, leaf1, pathIF)
+	s.GnmiGen.WaitPathPresent(t, leaf1, pathSys)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		TargetsCount: harness.I32(2),
+	})
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 15*time.Second, 2, leaf1, leaf2)
+}

--- a/test/integration/suite/008-distribution/distribution_test.go
+++ b/test/integration/suite/008-distribution/distribution_test.go
@@ -1,0 +1,599 @@
+//go:build integration
+
+// Package distribution covers target placement across collector pods:
+// balanced loads, podCapacity, rebalancing on scale, and the collected-once
+// invariant during and after membership changes.
+package distribution
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gnmic/operator/test/integration/harness"
+)
+
+var s *harness.Suite
+
+var allTargets = []string{
+	"dev1", "dev2", "dev3", "dev4", "dev5", "dev6", "dev7", "dev8", "dev9",
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(harness.RunSuite(m, harness.Options{
+		Name:           "008-distribution",
+		RequireTargets: allTargets,
+		Baseline:       []string{"fixtures/baseline.yaml"},
+	}, &s))
+}
+
+// waitIdle blocks until no suite target has an open stream. Previous tests'
+// collectors can linger briefly after Cluster deletion; starting the next
+// cluster before that settles makes stream-count assertions lie.
+func waitIdle(t *testing.T) {
+	t.Helper()
+	harness.Wait(t, harness.Medium, "all simulated targets idle", func() (bool, string) {
+		for _, name := range allTargets {
+			if n := s.GnmiGen.StreamCount(name); n != 0 {
+				return false, fmt.Sprintf("%s has %d streams", name, n)
+			}
+		}
+		return true, ""
+	})
+}
+
+// waitBalanced waits until every ready pod owns at least one target and loads
+// differ by at most one.
+func waitBalanced(t *testing.T, cluster string, replicas int, targets []string) {
+	t.Helper()
+	harness.Wait(t, harness.Medium, fmt.Sprintf("balanced placement across %d pods", replicas), func() (bool, string) {
+		as := assignments(t, cluster, targets)
+		loads := loadPerPod(as)
+		if len(loads) != replicas {
+			return false, fmt.Sprintf("owners=%v", loads)
+		}
+		min, max := -1, -1
+		for _, n := range loads {
+			if min < 0 || n < min {
+				min = n
+			}
+			if n > max {
+				max = n
+			}
+		}
+		if max-min > 1 {
+			return false, fmt.Sprintf("unbalanced %v", loads)
+		}
+		for _, name := range targets {
+			if as[name] == "" {
+				return false, name + " unassigned"
+			}
+		}
+		return true, ""
+	})
+}
+
+// startCluster applies a Cluster and a Pipeline binding the suite targets,
+// then waits until every expected target shows the expected stream count.
+func startCluster(t *testing.T, name string, replicas, podCapacity int, wantTargets []string) {
+	t.Helper()
+	waitIdle(t)
+	// Every optional template key is set: the fixture renderer uses
+	// missingkey=error, so a bare {{ if .PodCapacity }} still fails when absent.
+	s.K8s.ApplyFile(t, "fixtures/cluster.yaml", map[string]any{
+		"Name":        name,
+		"Image":       harness.GnmicImage(),
+		"Replicas":    replicas,
+		"PodCapacity": podCapacity,
+	})
+	s.K8s.ApplyFile(t, "fixtures/pipeline.yaml", map[string]any{
+		"Name":       name,
+		"Cluster":    name,
+		"ExtraLabel": "",
+		"ExtraValue": "",
+	})
+	s.K8s.WaitReadyPods(t, name, replicas, harness.Long)
+	if wantTargets != nil {
+		waitAssigned(t, name, wantTargets)
+		s.GnmiGen.AssertCollectedOnce(t, 1, wantTargets...)
+	}
+}
+
+func waitAssigned(t *testing.T, cluster string, targets []string) {
+	t.Helper()
+	harness.Wait(t, harness.Medium, "all targets assigned", func() (bool, string) {
+		as := assignments(t, cluster, targets)
+		missing := []string{}
+		for _, name := range targets {
+			if as[name] == "" {
+				missing = append(missing, name)
+			}
+		}
+		if len(missing) > 0 {
+			return false, fmt.Sprintf("unassigned: %v", missing)
+		}
+		return true, ""
+	})
+}
+
+// assignments returns target → owning pod for the given cluster.
+func assignments(t *testing.T, cluster string, targets []string) map[string]string {
+	t.Helper()
+	out := make(map[string]string, len(targets))
+	for _, name := range targets {
+		tgt, err := s.K8s.TargetQuiet(name)
+		if err != nil {
+			out[name] = ""
+			continue
+		}
+		if st, ok := tgt.Status.ClusterStates[cluster]; ok {
+			out[name] = st.Pod
+		}
+	}
+	return out
+}
+
+func loadPerPod(as map[string]string) map[string]int {
+	loads := map[string]int{}
+	for _, pod := range as {
+		if pod != "" {
+			loads[pod]++
+		}
+	}
+	return loads
+}
+
+func assertBalanced(t *testing.T, as map[string]string, replicas int) {
+	t.Helper()
+	loads := loadPerPod(as)
+	if len(loads) != replicas {
+		t.Fatalf("want %d pods owning targets, got %d: %v", replicas, len(loads), loads)
+	}
+	min, max := -1, -1
+	for _, n := range loads {
+		if min < 0 || n < min {
+			min = n
+		}
+		if n > max {
+			max = n
+		}
+	}
+	if max-min > 1 {
+		t.Fatalf("unbalanced loads: %v (max-min=%d)", loads, max-min)
+	}
+}
+
+func assertDisjoint(t *testing.T, as map[string]string) {
+	t.Helper()
+	seen := map[string]string{} // target → pod already checked; pairs of pods
+	byPod := map[string][]string{}
+	for tgt, pod := range as {
+		if pod == "" {
+			t.Errorf("target %s has no owner", tgt)
+			continue
+		}
+		byPod[pod] = append(byPod[pod], tgt)
+		if prev, ok := seen[tgt]; ok {
+			t.Errorf("target %s claimed by both %s and %s", tgt, prev, pod)
+		}
+		seen[tgt] = pod
+	}
+	// Pairwise disjoint is automatic if each target appears once; the map
+	// structure guarantees it. Sanity: every target appears exactly once.
+	if len(seen) != len(as) {
+		t.Errorf("assignment map size mismatch: %d keys, %d assigned", len(as), len(seen))
+	}
+	_ = byPod
+}
+
+func establishedSnapshot(targets []string) map[string]time.Time {
+	out := make(map[string]time.Time, len(targets))
+	for _, name := range targets {
+		out[name] = s.GnmiGen.EstablishedAt(name)
+	}
+	return out
+}
+
+func assertMostlyStable(t *testing.T, before, after map[string]string, maxMoved int) {
+	t.Helper()
+	moved := 0
+	for tgt, prev := range before {
+		if prev == "" {
+			continue
+		}
+		if after[tgt] != prev {
+			moved++
+		}
+	}
+	if moved > maxMoved {
+		t.Fatalf("moved %d targets, want at most %d\nbefore=%v\nafter=%v", moved, maxMoved, before, after)
+	}
+}
+
+func assertEstablishedPreserved(t *testing.T, before map[string]time.Time, asBefore, asAfter map[string]string) {
+	t.Helper()
+	for tgt, prevPod := range asBefore {
+		if prevPod == "" || asAfter[tgt] != prevPod {
+			continue
+		}
+		was := before[tgt]
+		now := s.GnmiGen.EstablishedAt(tgt)
+		if was.IsZero() || now.IsZero() {
+			continue
+		}
+		// Allow a small clock skew; a re-establish would jump by seconds.
+		if now.Sub(was).Abs() > time.Second {
+			t.Errorf("target %s re-established on %s: %s -> %s", tgt, prevPod, was, now)
+		}
+	}
+}
+
+// TestDist001_TargetsSpreadAcrossPods checks three replicas use all three pods
+// with balanced loads.
+func TestDist001_TargetsSpreadAcrossPods(t *testing.T) {
+	const cluster = "spread"
+	startCluster(t, cluster, 3, 0, allTargets)
+
+	as := assignments(t, cluster, allTargets)
+	assertBalanced(t, as, 3)
+	assertDisjoint(t, as)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		TargetsCount:      harness.I32(9),
+		UnassignedTargets: harness.I32(0),
+	})
+}
+
+// TestDist002_ExactlyOneCollectorPerTarget is the invariant on its own.
+func TestDist002_ExactlyOneCollectorPerTarget(t *testing.T) {
+	const cluster = "once"
+	startCluster(t, cluster, 3, 0, allTargets)
+
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 30*time.Second, 1, allTargets...)
+	assertDisjoint(t, assignments(t, cluster, allTargets))
+}
+
+// TestDist003_PodCapacityCapsPlacement checks podCapacity is a hard limit.
+func TestDist003_PodCapacityCapsPlacement(t *testing.T) {
+	const cluster = "cap"
+	startCluster(t, cluster, 3, 2, nil)
+
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		UnassignedTargets: harness.I32(3),
+		TargetsCount:      harness.I32(9),
+	})
+	harness.WaitClusterCondition(t, s.K8s, cluster, harness.CondCapacityExhausted, metav1.ConditionTrue, harness.Medium)
+
+	// Status and the wire can converge at different times; wait until both agree.
+	var gotAssigned, gotUnassigned []string
+	harness.Wait(t, harness.Medium, "capacity split: 6 collected, 3 idle", func() (bool, string) {
+		as := assignments(t, cluster, allTargets)
+		gotAssigned, gotUnassigned = nil, nil
+		loads := loadPerPod(as)
+		for _, n := range loads {
+			if n > 2 {
+				return false, fmt.Sprintf("load exceeds capacity: %v", loads)
+			}
+		}
+		for _, name := range allTargets {
+			streams := s.GnmiGen.StreamCount(name)
+			if as[name] == "" {
+				gotUnassigned = append(gotUnassigned, name)
+				if streams != 0 {
+					return false, fmt.Sprintf("%s unassigned but has %d streams", name, streams)
+				}
+			} else {
+				gotAssigned = append(gotAssigned, name)
+				if streams != 1 {
+					return false, fmt.Sprintf("%s assigned to %s but has %d streams", name, as[name], streams)
+				}
+			}
+		}
+		if len(gotAssigned) != 6 || len(gotUnassigned) != 3 {
+			return false, fmt.Sprintf("assigned=%v unassigned=%v", gotAssigned, gotUnassigned)
+		}
+		return true, ""
+	})
+}
+
+// TestDist004_CapacityExhaustionReported checks overflow is visible in status,
+// then clears when capacity is raised by scaling.
+func TestDist004_CapacityExhaustionReported(t *testing.T) {
+	const cluster = "capstat"
+	startCluster(t, cluster, 3, 2, nil)
+
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		UnassignedTargets: harness.I32(3),
+	})
+	harness.WaitClusterCondition(t, s.K8s, cluster, harness.CondCapacityExhausted, metav1.ConditionTrue, harness.Medium)
+
+	s.K8s.Patch(t, s.K8s.Cluster(t, cluster), `{"spec":{"replicas":5}}`)
+	s.K8s.WaitReadyPods(t, cluster, 5, harness.Long)
+	waitAssigned(t, cluster, allTargets)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		UnassignedTargets: harness.I32(0),
+		TargetsCount:      harness.I32(9),
+	})
+	harness.WaitClusterCondition(t, s.K8s, cluster, harness.CondCapacityExhausted, metav1.ConditionFalse, harness.Medium)
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+}
+
+// TestDist005_ScalingUpRebalances checks new pods receive work.
+func TestDist005_ScalingUpRebalances(t *testing.T) {
+	const cluster = "scaleup"
+	startCluster(t, cluster, 1, 0, allTargets)
+
+	s.K8s.Patch(t, s.K8s.Cluster(t, cluster), `{"spec":{"replicas":3}}`)
+	s.K8s.WaitReadyPods(t, cluster, 3, harness.Long)
+	waitBalanced(t, cluster, 3, allTargets)
+
+	as := assignments(t, cluster, allTargets)
+	assertBalanced(t, as, 3)
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+}
+
+// TestDist006_ScalingUpMovesFewTargets checks bounded-hashing stability.
+func TestDist006_ScalingUpMovesFewTargets(t *testing.T) {
+	const cluster = "stable"
+	startCluster(t, cluster, 2, 0, allTargets)
+
+	before := assignments(t, cluster, allTargets)
+	estab := establishedSnapshot(allTargets)
+
+	s.K8s.Patch(t, s.K8s.Cluster(t, cluster), `{"spec":{"replicas":3}}`)
+	s.K8s.WaitReadyPods(t, cluster, 3, harness.Long)
+	waitAssigned(t, cluster, allTargets)
+
+	after := assignments(t, cluster, allTargets)
+	assertBalanced(t, after, 3)
+	assertMostlyStable(t, before, after, 5)
+	assertEstablishedPreserved(t, estab, before, after)
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+}
+
+// TestDist007_ScalingDownReassignsOrphans checks targets leave removed pods.
+func TestDist007_ScalingDownReassignsOrphans(t *testing.T) {
+	const cluster = "scaledown"
+	startCluster(t, cluster, 3, 0, allTargets)
+
+	before := assignments(t, cluster, allTargets)
+	orphans := []string{}
+	pod2 := harness.PodName(cluster, 2)
+	for tgt, pod := range before {
+		if pod == pod2 {
+			orphans = append(orphans, tgt)
+		}
+	}
+	if len(orphans) == 0 {
+		t.Fatal("pod-2 owns no targets; cannot assert reassignment")
+	}
+
+	s.K8s.Patch(t, s.K8s.Cluster(t, cluster), `{"spec":{"replicas":2}}`)
+	s.K8s.WaitPodGone(t, pod2)
+	s.K8s.WaitReadyPods(t, cluster, 2, harness.Long)
+	waitAssigned(t, cluster, allTargets)
+
+	after := assignments(t, cluster, allTargets)
+	for _, tgt := range orphans {
+		if after[tgt] == "" || after[tgt] == pod2 {
+			t.Errorf("orphan %s not reassigned; owner=%q", tgt, after[tgt])
+		}
+	}
+	assertBalanced(t, after, 2)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{ReadyReplicas: harness.I32(2)})
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+}
+
+// TestDist008_NoDoubleCollectionDuringScale holds the invariant during a
+// scale transition, not only after it settles.
+//
+// A single sample at 2 can be a polling race against gNMIc tearing down a
+// stream after config/apply returns. Sustained doubles (≥1s consecutive) are
+// the real bug: start-on-new before stop-on-old.
+func TestDist008_NoDoubleCollectionDuringScale(t *testing.T) {
+	const cluster = "transition"
+	startCluster(t, cluster, 2, 0, allTargets)
+
+	var (
+		mu          sync.Mutex
+		doubleFor   = map[string]time.Duration{}
+		doubleSince = map[string]time.Time{}
+		zeroFor     = map[string]time.Duration{}
+		lastZero    = map[string]time.Time{}
+		stop        = make(chan struct{})
+		done        = make(chan struct{})
+	)
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(250 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				now := time.Now()
+				for _, name := range allTargets {
+					n := s.GnmiGen.StreamCount(name)
+					mu.Lock()
+					switch {
+					case n > 1:
+						if doubleSince[name].IsZero() {
+							doubleSince[name] = now
+						}
+					default:
+						if !doubleSince[name].IsZero() {
+							if d := now.Sub(doubleSince[name]); d > doubleFor[name] {
+								doubleFor[name] = d
+							}
+							doubleSince[name] = time.Time{}
+						}
+					}
+					if n == 0 {
+						if lastZero[name].IsZero() {
+							lastZero[name] = now
+						}
+					} else if !lastZero[name].IsZero() {
+						if d := now.Sub(lastZero[name]); d > zeroFor[name] {
+							zeroFor[name] = d
+						}
+						lastZero[name] = time.Time{}
+					}
+					mu.Unlock()
+				}
+			}
+		}
+	}()
+
+	s.K8s.Patch(t, s.K8s.Cluster(t, cluster), `{"spec":{"replicas":4}}`)
+	s.K8s.WaitReadyPods(t, cluster, 4, harness.Long)
+	waitAssigned(t, cluster, allTargets)
+	s.K8s.Patch(t, s.K8s.Cluster(t, cluster), `{"spec":{"replicas":2}}`)
+	s.K8s.WaitReadyPods(t, cluster, 2, harness.Long)
+	waitAssigned(t, cluster, allTargets)
+
+	close(stop)
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	const maxDouble = time.Second
+	const maxZero = 30 * time.Second
+	for _, name := range allTargets {
+		dup := doubleFor[name]
+		if !doubleSince[name].IsZero() {
+			if d := time.Since(doubleSince[name]); d > dup {
+				dup = d
+			}
+		}
+		if dup > maxDouble {
+			t.Errorf("%s double-collected for %s (limit %s)", name, dup, maxDouble)
+		}
+		gap := zeroFor[name]
+		if !lastZero[name].IsZero() {
+			if d := time.Since(lastZero[name]); d > gap {
+				gap = d
+			}
+		}
+		if gap > maxZero {
+			t.Errorf("%s was at zero streams for %s (limit %s)", name, gap, maxZero)
+		}
+	}
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+}
+
+// TestDist009_PodDeletionRecoversAssignments checks unplanned pod loss.
+func TestDist009_PodDeletionRecoversAssignments(t *testing.T) {
+	const cluster = "poddel"
+	startCluster(t, cluster, 3, 0, allTargets)
+
+	before := assignments(t, cluster, allTargets)
+	estab := establishedSnapshot(allTargets)
+	victim := harness.PodName(cluster, 1)
+
+	pod := &corev1.Pod{}
+	pod.Name = victim
+	pod.Namespace = s.Namespace
+	// The StatefulSet recreates the pod immediately, so do not wait for absence.
+	s.K8s.DeleteNow(t, pod)
+
+	s.K8s.WaitReadyPods(t, cluster, 3, harness.Long)
+	waitAssigned(t, cluster, allTargets)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{ReadyReplicas: harness.I32(3)})
+
+	after := assignments(t, cluster, allTargets)
+	for tgt, pod := range after {
+		if pod == "" {
+			t.Errorf("%s has no owner after recovery", tgt)
+		}
+	}
+	assertEstablishedPreserved(t, estab, before, after)
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+}
+
+// TestDist010_AddingTargetDoesNotChurnExisting checks membership growth is
+// minimally disruptive.
+func TestDist010_AddingTargetDoesNotChurnExisting(t *testing.T) {
+	const cluster = "add"
+	// Hold dev9 out of the pipeline by clearing its suite label, then restore.
+	dev9 := s.K8s.Target(t, "dev9")
+	s.K8s.Patch(t, dev9, `{"metadata":{"labels":{"suite":null}}}`)
+	t.Cleanup(func() {
+		s.K8s.Patch(t, s.K8s.Target(t, "dev9"), `{"metadata":{"labels":{"suite":"008"}}}`)
+	})
+
+	eight := allTargets[:8]
+	startCluster(t, cluster, 3, 0, eight)
+
+	before := assignments(t, cluster, eight)
+	estab := establishedSnapshot(eight)
+
+	s.K8s.Patch(t, s.K8s.Target(t, "dev9"), `{"metadata":{"labels":{"suite":"008"}}}`)
+	waitAssigned(t, cluster, allTargets)
+
+	after := assignments(t, cluster, allTargets)
+	if after["dev9"] == "" {
+		t.Fatal("dev9 was not assigned")
+	}
+	s.GnmiGen.WaitStreams(t, "dev9", 1)
+
+	moved := 0
+	for _, name := range eight {
+		if before[name] != after[name] {
+			moved++
+		}
+	}
+	if moved > 1 {
+		t.Fatalf("adding one target moved %d existing owners; want at most 1", moved)
+	}
+	assertEstablishedPreserved(t, estab, before, after)
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+}
+
+// TestDist011_RemovingTargetDoesNotChurnRest checks clean removal.
+func TestDist011_RemovingTargetDoesNotChurnRest(t *testing.T) {
+	const cluster = "remove"
+	startCluster(t, cluster, 3, 0, allTargets)
+
+	before := assignments(t, cluster, allTargets)
+	estab := establishedSnapshot(allTargets)
+
+	s.K8s.Delete(t, s.K8s.Target(t, "dev5"))
+	t.Cleanup(func() {
+		dev5 := `
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: dev5
+  labels:
+    suite: "008"
+spec:
+  address: ` + s.TargetAddress(4) + `
+  profile: default
+`
+		if _, err := s.K8s.ApplyYAMLNoCleanup(dev5, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "restore dev5: %v\n", err)
+		}
+	})
+
+	s.GnmiGen.WaitStreams(t, "dev5", 0)
+	rest := []string{"dev1", "dev2", "dev3", "dev4", "dev6", "dev7", "dev8", "dev9"}
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{TargetsCount: harness.I32(8)})
+
+	after := assignments(t, cluster, rest)
+	moved := 0
+	for _, name := range rest {
+		if before[name] != after[name] {
+			moved++
+		}
+	}
+	if moved > 1 {
+		t.Fatalf("removing one target moved %d others; want at most 1", moved)
+	}
+	assertEstablishedPreserved(t, estab, before, after)
+	s.GnmiGen.AssertCollectedOnce(t, 1, rest...)
+}

--- a/test/integration/suite/008-distribution/fixtures/baseline.yaml
+++ b/test/integration/suite/008-distribution/fixtures/baseline.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sim-credentials
+stringData:
+  username: gnmic
+  password: gnmic
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: TargetProfile
+metadata:
+  name: default
+spec:
+  credentialsRef: sim-credentials
+  encoding: JSON_IETF
+  timeout: 10s
+  tls: {}
+  retryTimer: 2s
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: if-counters
+  labels:
+    suite: "008"
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 1s
+  encoding: JSON_IETF
+  paths:
+    - /interface/statistics/in-octets
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: sink
+  labels:
+    suite: "008"
+spec:
+  type: file
+  config:
+    filename: /tmp/008-sink.json
+    format: event
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: dev1
+  labels:
+    suite: "008"
+spec:
+  address: {{ .GnmiGenHost }}:57400
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: dev2
+  labels:
+    suite: "008"
+spec:
+  address: {{ .GnmiGenHost }}:57401
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: dev3
+  labels:
+    suite: "008"
+spec:
+  address: {{ .GnmiGenHost }}:57402
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: dev4
+  labels:
+    suite: "008"
+spec:
+  address: {{ .GnmiGenHost }}:57403
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: dev5
+  labels:
+    suite: "008"
+spec:
+  address: {{ .GnmiGenHost }}:57404
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: dev6
+  labels:
+    suite: "008"
+spec:
+  address: {{ .GnmiGenHost }}:57405
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: dev7
+  labels:
+    suite: "008"
+spec:
+  address: {{ .GnmiGenHost }}:57406
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: dev8
+  labels:
+    suite: "008"
+spec:
+  address: {{ .GnmiGenHost }}:57407
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: dev9
+  labels:
+    suite: "008"
+spec:
+  address: {{ .GnmiGenHost }}:57408
+  profile: default

--- a/test/integration/suite/008-distribution/fixtures/cluster.yaml
+++ b/test/integration/suite/008-distribution/fixtures/cluster.yaml
@@ -1,0 +1,13 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: {{ .Name }}
+spec:
+  image: {{ .Image }}
+  replicas: {{ .Replicas }}
+  api:
+    restPort: 7890
+{{- if gt .PodCapacity 0 }}
+  targetDistribution:
+    podCapacity: {{ .PodCapacity }}
+{{- end }}

--- a/test/integration/suite/008-distribution/fixtures/pipeline.yaml
+++ b/test/integration/suite/008-distribution/fixtures/pipeline.yaml
@@ -1,0 +1,20 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: {{ .Name }}
+spec:
+  clusterRef: {{ .Cluster }}
+  enabled: true
+  targetSelectors:
+    - matchLabels:
+        suite: "008"
+{{- if ne .ExtraLabel "" }}
+        {{ .ExtraLabel }}: "{{ .ExtraValue }}"
+{{- end }}
+  subscriptionSelectors:
+    - matchLabels:
+        suite: "008"
+  outputs:
+    outputSelectors:
+      - matchLabels:
+          suite: "008"

--- a/test/integration/suite/008-distribution/gnmi-gen.yaml
+++ b/test/integration/suite/008-distribution/gnmi-gen.yaml
@@ -1,0 +1,42 @@
+global:
+  seed: 42
+  shutdown_timeout: 5s
+
+api:
+  listen: 0.0.0.0:8080
+
+data_profiles:
+  interface_counter:
+    type: uint64
+    update_frequency: 1s
+    random:
+      distribution: counter
+      min: 100000
+      max: 900000
+      step_min: 100
+      step_max: 10000
+
+  system_name:
+    type: string
+    update_frequency: 10s
+    random:
+      value: dev-{{.index}}
+
+servers:
+  - name: dev{{.index}}
+    expand:
+      index:
+        start: 1
+        end: 9
+      listen:
+        host: 0.0.0.0
+        port_start: 57400
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name


### PR DESCRIPTION
Add a kind-based assertion suite with device-side stream checks, and fix Cluster apply so empty plans clear collectors and scale/pipeline races do not double-collect or leave stale status.