### PR TITLE
perf: reduce reconcile amplification for large target populations

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,6 +71,8 @@ func main() {
 	var apiAddr string
 	var discoveryChunkSize int
 	var discoveryBufferSize int
+	var kubeAPIQPS float64
+	var kubeAPIBurst int
 	flag.StringVar(&apiAddr, "api-bind-address", "", "The address the operator API endpoint binds to. Disabled if empty.")
 	flag.BoolVar(&devMode, "dev-mode", false, "Enable development mode.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -80,6 +82,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.IntVar(&discoveryChunkSize, "discovery-chunk-size", 100, "Maximum number of targets/events sent in a single discovery message.")
 	flag.IntVar(&discoveryBufferSize, "discovery-buffer-size", 10, "Amount of discovery messages that can be queued in the channel buffer.")
+	flag.Float64Var(&kubeAPIQPS, "kube-api-qps", 50, "Maximum sustained queries per second to the Kubernetes API server. The client-go default (20) is too low for large target populations.")
+	flag.IntVar(&kubeAPIBurst, "kube-api-burst", 100, "Maximum burst of queries to the Kubernetes API server.")
 	opts := zap.Options{
 		Development: devMode,
 	}
@@ -90,7 +94,15 @@ func main() {
 
 	discoveryRegistry := discovery.NewRegistry[types.NamespacedName, core.DiscoveryRegistryValue]()
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	// The rest-client defaults (20 QPS / 30 burst) throttle every controller in the
+	// process behind whichever one is busiest. With a few thousand Targets that shows up
+	// as inexplicably slow Cluster reconciles rather than as an obvious error.
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.QPS = float32(kubeAPIQPS)
+	restConfig.Burst = kubeAPIBurst
+	setupLog.Info("configured Kubernetes API client rate limits", "qps", restConfig.QPS, "burst", restConfig.Burst)
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: probeAddr,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - secrets
   - services
   verbs:
   - create
@@ -21,8 +20,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
+  - secrets
   verbs:
+  - get
   - list
   - watch
 - apiGroups:

--- a/helm/templates/clusterrole.yaml
+++ b/helm/templates/clusterrole.yaml
@@ -9,7 +9,6 @@ rules:
       - ""
     resources:
       - configmaps
-      - secrets
       - services
     verbs:
       - create
@@ -22,8 +21,9 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
+      - secrets
     verbs:
+      - get
       - list
       - watch
   - apiGroups:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
             {{- end }}
             - --discovery-chunk-size={{ .Values.discovery.chunkSize }}
             - --discovery-buffer-size={{ .Values.discovery.bufferSize }}
+            - --kube-api-qps={{ .Values.kubeApi.qps }}
+            - --kube-api-burst={{ .Values.kubeApi.burst }}
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -36,13 +36,23 @@ securityContext:
     drop:
       - "ALL"
 
+# Memory scales with the number of cached objects, not just Target count: the manager
+# caches every Secret, ConfigMap, Service, StatefulSet and Certificate in the cluster.
+# 256Mi is not enough for a few thousand Targets. Measure RSS in your own environment and
+# raise these above the observed peak with headroom.
 resources:
   limits:
     cpu: 500m
-    memory: 256Mi
+    memory: 1Gi
   requests:
-    cpu: 10m
-    memory: 64Mi
+    cpu: 100m
+    memory: 256Mi
+
+# Kubernetes API client rate limits. The client-go defaults (20 QPS / 30 burst) throttle
+# every controller in the process behind whichever one is busiest.
+kubeApi:
+  qps: 50
+  burst: 100
 
 nodeSelector: {}
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -78,6 +78,11 @@ const (
 	clusterFinalizer  = "operator.gnmic.dev/cluster-finalizer"
 	defaultRestPort   = 7890
 	controllerCACMSfx = "-controller-ca"
+
+	// readinessBackstopInterval is how often to re-check StatefulSet readiness when it is
+	// not yet satisfied. Readiness changes already arrive via the Owns(&appsv1.StatefulSet{})
+	// watch, so this only needs to cover a missed event, not to drive the wait.
+	readinessBackstopInterval = 20 * time.Second
 )
 
 // Condition types for Cluster status
@@ -136,8 +141,9 @@ func (r *ClusterReconciler) FetchCredentials(namespace, secretRef string) (*gnmi
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=pods,verbs=list;watch
+// Secrets are read-only everywhere in this operator (credential and issuer-CA lookups);
+// list and watch are required because they are served from the informer cache.
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch
 
@@ -357,8 +363,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 			pipelineData.TargetProfiles[targetProfile.Namespace+gnmic.Delimiter+targetProfile.Name] = targetProfile.Spec
 		}
-		logger.Info("cluster pipeline targets", "targets", targets)
-		logger.Info("cluster pipeline target profiles", "targetProfiles", targetProfilesNames)
+		logger.Info("cluster pipeline resolved targets", "count", len(targets), "targetProfiles", len(targetProfilesNames))
 
 		// retrieve subscriptions for this pipeline
 		subscriptions, err := r.resolveSubscriptions(ctx, &pipeline)
@@ -368,7 +373,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		for _, subscription := range subscriptions {
 			pipelineData.Subscriptions[subscription.Namespace+gnmic.Delimiter+subscription.Name] = subscription.Spec
 		}
-		logger.Info("cluster pipeline subscriptions", "subscriptions", subscriptions)
+		logger.Info("cluster pipeline resolved subscriptions", "count", len(subscriptions))
 
 		// retrieve outputs for this pipeline
 		outputs, err := r.resolveOutputs(ctx, &pipeline)
@@ -390,7 +395,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				}
 			}
 		}
-		logger.Info("cluster pipeline outputs", "outputs", outputs)
+		logger.Info("cluster pipeline resolved outputs", "count", len(outputs))
 
 		// retrieve inputs for this pipeline
 		inputs, err := r.resolveInputs(ctx, &pipeline)
@@ -400,7 +405,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		for _, input := range inputs {
 			pipelineData.Inputs[pipelineNN+gnmic.Delimiter+input.Name] = input.Spec
 		}
-		logger.Info("cluster pipeline inputs", "inputs", inputs)
+		logger.Info("cluster pipeline resolved inputs", "count", len(inputs))
 
 		// retrieve output processors for this pipeline (order: refs first, then sorted selectors)
 		outputProcessors, err := r.resolveOutputProcessors(ctx, &pipeline)
@@ -412,7 +417,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			pipelineData.OutputProcessors[processorNN] = processor.Spec
 			pipelineData.OutputProcessorOrder = append(pipelineData.OutputProcessorOrder, processorNN)
 		}
-		logger.Info("cluster pipeline output processors", "outputProcessors", outputProcessors)
+		logger.Info("cluster pipeline resolved output processors", "count", len(outputProcessors))
 
 		// retrieve input processors for this pipeline (order: refs first, then sorted selectors)
 		inputProcessors, err := r.resolveInputProcessors(ctx, &pipeline)
@@ -424,7 +429,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			pipelineData.InputProcessors[processorNN] = processor.Spec
 			pipelineData.InputProcessorOrder = append(pipelineData.InputProcessorOrder, processorNN)
 		}
-		logger.Info("cluster pipeline input processors", "inputProcessors", inputProcessors)
+		logger.Info("cluster pipeline resolved input processors", "count", len(inputProcessors))
 
 		// retrieve tunnel target policies for this pipeline
 		tunnelTargetPolicies, err := r.resolveTunnelTargetPolicies(ctx, &pipeline)
@@ -496,8 +501,13 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	desiredReplicas := ptr.Deref(statefulSet.Spec.Replicas, 0)
 	// only apply new config when all desired replicas are ready
 	if statefulSet.Status.ReadyReplicas < desiredReplicas {
-		logger.Info("waiting for gNMIc pods to be ready before applying config")
-		return ctrl.Result{RequeueAfter: time.Second}, nil
+		logger.Info("waiting for gNMIc pods to be ready before applying config",
+			"readyReplicas", statefulSet.Status.ReadyReplicas, "desiredReplicas", desiredReplicas)
+		// The StatefulSet is watched via Owns() with no predicate, so ReadyReplicas
+		// transitions already wake this controller. This requeue is only a backstop for a
+		// missed event; at 1s it re-ran the entire plan build once per second for the whole
+		// duration of a rollout.
+		return ctrl.Result{RequeueAfter: readinessBackstopInterval}, nil
 	}
 	// A reconcile queued while Pipelines were empty can run after a newer
 	// reconcile already applied a non-empty plan. Re-list immediately before

--- a/internal/controller/discovery/message_processor.go
+++ b/internal/controller/discovery/message_processor.go
@@ -234,6 +234,13 @@ func (m *MessageProcessor) processEvent(ctx context.Context, event core.Discover
 	// Apply events
 	err := m.applyEvent(ctx, event, logger)
 	if err == nil {
+		// Logged here rather than in applyEvent: this is the single-event path, whereas
+		// applySnapshot calls applyEvent once per discovered target and logs aggregate
+		// counts instead.
+		logger.Info("applied discovery event",
+			"event", event.Event,
+			"name", event.Target.Name,
+		)
 		switch event.Event {
 		case core.EventApply:
 			m.targetCount++
@@ -345,10 +352,6 @@ func (m *MessageProcessor) applyEvent(ctx context.Context, event core.DiscoveryE
 				"targetName", event.Target.Name,
 			)
 			return err
-		} else {
-			logger.Info("deleted target object",
-				"name", event.Target.Name,
-			)
 		}
 	case core.EventApply:
 		target := generateTargetResource(event.Target, m.targetSource)
@@ -358,10 +361,6 @@ func (m *MessageProcessor) applyEvent(ctx context.Context, event core.DiscoveryE
 				"targetName", event.Target.Name,
 			)
 			return err
-		} else {
-			logger.Info("applied target object",
-				"name", event.Target.Name,
-			)
 		}
 	}
 

--- a/internal/gnmic/plan.go
+++ b/internal/gnmic/plan.go
@@ -43,6 +43,11 @@ type PlanBuilder struct {
 	prometheusOutputPorts map[string]map[string]int32
 	// target distribution capacity
 	targetDistributionCapacity int
+	// credsCache memoises credential lookups for the duration of a single Build().
+	// Thousands of targets typically share a handful of secrets, so without this the
+	// same secret is fetched once per target. Deliberately not retained across builds:
+	// a longer-lived cache would stop credential rotation from taking effect.
+	credsCache map[string]*Credentials
 }
 
 type resourceRelationship struct {
@@ -104,6 +109,9 @@ func (b *PlanBuilder) Build() (*ApplyPlan, error) {
 		TunnelTargetMatches:     make(map[string]*TunnelTargetMatch),
 		PrometheusPorts:         make(map[string]int32),
 	}
+	// Credentials are memoised per build only — see credsCache.
+	b.credsCache = make(map[string]*Credentials)
+
 	// 1) collect relationships across all pipelines
 	b.collectRelationships(plan)
 
@@ -269,6 +277,25 @@ func (b *PlanBuilder) findTargetCurrentAssignmentBoundedLoadHashing(targetCR v1a
 	return &podIdx
 }
 
+// fetchCredentialsCached resolves a secret reference, reusing any value already fetched
+// during the current Build(). The cache is cleared at the start of every Build() so that a
+// rotated secret is picked up on the next reconcile.
+func (b *PlanBuilder) fetchCredentialsCached(namespace, secretRef string) (*Credentials, error) {
+	key := namespace + Delimiter + secretRef
+	if creds, ok := b.credsCache[key]; ok {
+		return creds, nil
+	}
+	creds, err := b.credsFetcher.FetchCredentials(namespace, secretRef)
+	if err != nil {
+		return nil, err
+	}
+	if b.credsCache == nil {
+		b.credsCache = make(map[string]*Credentials)
+	}
+	b.credsCache[key] = creds
+	return creds, nil
+}
+
 func (b *PlanBuilder) buildTargets(plan *ApplyPlan, pipelineData *PipelineData) error {
 	for targetNN, target := range pipelineData.Targets {
 		if _, ok := plan.Targets[targetNN]; ok {
@@ -287,7 +314,7 @@ func (b *PlanBuilder) buildTargets(plan *ApplyPlan, pipelineData *PipelineData) 
 		var creds *Credentials
 		if profileSpec.CredentialsRef != "" && b.credsFetcher != nil {
 			var err error
-			creds, err = b.credsFetcher.FetchCredentials(namespace, profileSpec.CredentialsRef)
+			creds, err = b.fetchCredentialsCached(namespace, profileSpec.CredentialsRef)
 			if err != nil {
 				return err
 			}
@@ -430,7 +457,7 @@ func (b *PlanBuilder) buildTunnelTargetMatches(plan *ApplyPlan, pipelineData *Pi
 		var creds *Credentials
 		if profileSpec.CredentialsRef != "" && b.credsFetcher != nil {
 			var err error
-			creds, err = b.credsFetcher.FetchCredentials(namespace, profileSpec.CredentialsRef)
+			creds, err = b.fetchCredentialsCached(namespace, profileSpec.CredentialsRef)
 			if err != nil {
 				return err
 			}

--- a/internal/gnmic/sse.go
+++ b/internal/gnmic/sse.go
@@ -105,9 +105,16 @@ func StreamTargetState(ctx context.Context, httpClient *http.Client, podURL stri
 				continue
 			}
 
-			events <- SSEEvent{
+			// A bare send here blocks forever once the buffer is full and the consumer
+			// has stopped draining, so the goroutine never returns to scanner.Scan(),
+			// never observes the closed body, and leaks along with its connection.
+			select {
+			case events <- SSEEvent{
 				EventType: currentEventType,
 				Data:      data,
+			}:
+			case <-ctx.Done():
+				return ctx.Err()
 			}
 		}
 	}


### PR DESCRIPTION
Localized changes that cut the work done per reconcile at high Target CR count.

Readiness requeue 1s -> 20s (readinessBackstopInterval). The StatefulSet is watched via Owns() with no predicate, so ReadyReplicas transitions already wake the controller; the requeue only needs to cover a missed event. At 1s the entire plan was rebuilt and discarded once per second for the whole duration of a rollout. Also log ready/desired counts when waiting.

Whole-object logging removed. Six sites in the Cluster reconcile logged fully serialised objects at Info on every pass.

The discovery apply path logged one line per target, which at snapshot scale is thousands per sync. Those are removed from applyEvent, where both the bulk and single-event paths converge; applySnapshot already logs aggregate apply/delete counts. A single line moves to processEvent so the incremental path still reports what it did without reintroducing the bulk volume. Error logging is unchanged throughout.

Credentials memoised per Build(). buildTargets and buildTunnelTargetMatches called FetchCredentials once per target, so a few thousand targets sharing a handful of secrets produced a lookup each. The cache is allocated fresh in Build() and deliberately not retained across builds -- a longer-lived cache would stop credential rotation from taking effect.

Kubernetes API client rate limits made configurable via --kube-api-qps and --kube-api-burst, defaulting to 50/100 and surfaced in the chart as kubeApi.qps / kubeApi.burst. The client-go defaults (20 QPS / 30 burst) throttle every controller in the process behind whichever one is busiest, which shows up as inexplicably slow Cluster reconciles rather than an error.

Chart memory defaults raised: limits 256Mi -> 1Gi, requests 64Mi -> 256Mi and cpu 10m -> 100m. The manager caches every Secret, ConfigMap, Service, StatefulSet and Certificate in the cluster, so footprint is driven by total cached objects rather than Target count alone. These are estimates, not measurements -- values.yaml now says so and points at measuring RSS.

SSE channel send made cancellable. StreamTargetState sent into the event channel unconditionally; once the 1024-slot buffer filled and the consumer stopped draining, the producer blocked forever, never returned to scanner.Scan(), never observed the closed body, and leaked along with its HTTP connection. Since streams are cancelled and restarted on every Cluster spec change, this accumulated.

RBAC narrowed to observed usage. Secrets are read-only on every code path (credential and issuer-CA lookups), so the grant drops from full CRUD to get;list;watch -- list and watch are still needed because reads are served from the informer cache. The pods grant is removed outright: no code reads a Pod object, since pods are addressed by ordinal StatefulSet DNS. Regenerated config/rbac/role.yaml and hand-synced helm/templates/clusterrole.yaml, which is maintained separately and not covered by the CRD drift check.