### PR TITLE
perf: stop re-sending unchanged config to the collector pods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -155,9 +155,16 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+	// Shared between the Cluster and TargetState controllers: the first records
+	// what it applied to each pod, the second invalidates a pod's record when
+	// its SSE stream drops, which is the operator's only sign that a pod may
+	// have restarted and lost its configuration.
+	applyCache := controller.NewApplyCache()
+
 	clusterReconciler := &controller.ClusterReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Applied: applyCache,
 	}
 	if err = clusterReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cluster")
@@ -254,8 +261,9 @@ func main() {
 		}
 	}
 	if err = (&controller.TargetStateReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Applied: applyCache,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TargetState")
 		os.Exit(1)

--- a/docs/content/docs/advanced/operator-resources.md
+++ b/docs/content/docs/advanced/operator-resources.md
@@ -123,6 +123,35 @@ Raise these if you see reconcile latency that does not correspond to API server 
 Client-go logs waits longer than a second, and the `rest_client_rate_limiter_duration_seconds`
 metric shows time spent waiting on the limiter.
 
+## Configuration pushes to the collectors
+
+The operator does not re-send a collector's configuration when nothing about it has changed.
+
+It fingerprints the exact payload it POSTs to each pod and skips the request when the pod
+already holds that configuration. This matters because many things legitimately trigger a
+`Cluster` reconcile — a `Target` edit, a rotated credential Secret, a StatefulSet status
+update — and without this each one re-sent the full configuration to every pod, twice, since
+the apply runs a shrink pass followed by an install pass.
+
+The record is per pod, held in operator memory, and is dropped whenever the operator has
+reason to doubt it:
+
+| Event | Effect |
+|---|---|
+| Pod restarts | Its SSE stream drops; that pod alone is re-configured on the next reconcile |
+| A push fails | Nothing is recorded, so the next reconcile retries |
+| Cluster deleted | All records for that cluster are dropped |
+| Operator restarts | The record is empty; every pod is re-configured once |
+
+**One case is not detected.** If a pod's configuration is changed out of band — by calling
+gNMIc's REST API on the pod directly, for instance `DELETE /api/v1/config/targets/{id}` —
+the pod's connection to the operator stays up and nothing reports the change. The operator
+re-sends unconditionally once its record is older than **5 minutes**, so an out-of-band edit
+is reverted within that window rather than immediately.
+
+If you are testing a change by poking a pod's API directly, expect it to be undone. Change
+the CRs instead.
+
 ## Memory sizing
 
 The chart ships:

--- a/docs/content/docs/advanced/scaling.md
+++ b/docs/content/docs/advanced/scaling.md
@@ -37,14 +37,16 @@ spec:
 3. Operator recomputes the distribution plan. Existing target assignments are
    preserved — only unassigned targets or targets displaced by capacity limits
    are placed on the new pods.
-4. Configuration is applied to all pods.
+4. Configuration is applied to the pods whose assignment changed. Pods already holding
+   the right configuration are skipped — see
+   [Configuration pushes to the collectors](../operator-resources/#configuration-pushes-to-the-collectors).
 
 ### Scale Down ( 5 → 3 pods)
 
 1. Operator recomputes the distribution plan for the reduced replica count.
    Targets from removed pods flow through rendezvous hashing onto surviving
    pods, bounded by each pod's capacity.
-2. Configuration is applied to remaining pods.
+2. Configuration is applied to the remaining pods whose assignment changed.
 3. Kubernetes terminates pods (`gnmic-4`, `gnmic-3`).
 
 ## Target Redistribution
@@ -309,5 +311,6 @@ All pods connect to all outputs. For outputs like Kafka or Prometheus:
 
 gNMIc pods are stateless by design:
 - No persistent volumes required
-- Configuration comes from operator via REST API
+- Configuration comes from operator via REST API, and is re-sent automatically when a pod
+  restarts
 - Targets can move between pods without data loss

--- a/internal/controller/applycache.go
+++ b/internal/controller/applycache.go
@@ -1,0 +1,121 @@
+package controller
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"sync"
+	"time"
+)
+
+// applyRefreshInterval bounds how long the short-circuit will trust its own
+// record of what a pod holds.
+//
+// The cache is invalidated by evidence — an apply failure, or the pod's SSE
+// stream dropping — but a pod can also lose its configuration without either:
+// a gNMIc bug, or somebody calling DELETE on its REST API. Nothing tells the
+// operator that happened, and gNMIc exposes no cheap way to ask (GET
+// /api/v1/config returns the entire configuration, so verifying costs as much
+// as re-applying). Re-applying unconditionally past this interval bounds that
+// blind spot without giving up the reduction: a reconcile storm still collapses
+// to one apply per pod per interval.
+const applyRefreshInterval = 5 * time.Minute
+
+// ApplyCache records what was last successfully applied to each collector pod,
+// so a reconcile that changes nothing does not re-POST the whole configuration
+// to every pod.
+//
+// It is deliberately in-memory and unshared between operator instances: losing
+// it costs one redundant apply per pod, which is the safe direction to fail.
+// Persisting it would make a stale entry survive the restart that might have
+// been the only thing left to clear it.
+type ApplyCache struct {
+	mu      sync.Mutex
+	entries map[string]applyRecord
+	ttl     time.Duration
+	// now is swappable for tests; nil means time.Now.
+	now func() time.Time
+}
+
+type applyRecord struct {
+	hash string
+	at   time.Time
+}
+
+// NewApplyCache returns a cache using the default refresh interval.
+func NewApplyCache() *ApplyCache {
+	return &ApplyCache{entries: make(map[string]applyRecord), ttl: applyRefreshInterval}
+}
+
+func (c *ApplyCache) timeNow() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// Unchanged reports whether the pod already holds this exact configuration and
+// the record is still inside the refresh interval.
+//
+// A nil cache always reports false, so a reconciler constructed without one
+// (tests, the API server) applies unconditionally rather than silently skipping.
+func (c *ApplyCache) Unchanged(key, hash string) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	rec, ok := c.entries[key]
+	if !ok || rec.hash != hash {
+		return false
+	}
+	return c.timeNow().Sub(rec.at) < c.ttl
+}
+
+// Record marks a configuration as successfully applied to a pod. It must only
+// be called after the POST succeeds: recording an attempt would make a failed
+// apply look applied until the plan changes again.
+func (c *ApplyCache) Record(key, hash string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = applyRecord{hash: hash, at: c.timeNow()}
+}
+
+// Invalidate drops one pod's record, forcing the next reconcile to re-apply to
+// that pod alone.
+func (c *ApplyCache) Invalidate(key string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, key)
+}
+
+// InvalidateCluster drops every pod record belonging to a cluster. Used when
+// the cluster is deleted, so entries do not accumulate for clusters that no
+// longer exist.
+func (c *ApplyCache) InvalidateCluster(namespace, name string) {
+	if c == nil {
+		return
+	}
+	prefix := namespace + "/" + name + "/"
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.entries {
+		if strings.HasPrefix(key, prefix) {
+			delete(c.entries, key)
+		}
+	}
+}
+
+// fingerprint hashes the exact bytes that go on the wire rather than the plan
+// struct, so two structs that marshal identically compare equal and any change
+// in what is actually sent is a change here.
+func fingerprint(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/controller/applycache_test.go
+++ b/internal/controller/applycache_test.go
@@ -1,0 +1,114 @@
+package controller
+
+import (
+	"testing"
+	"time"
+)
+
+func testCache(t *testing.T, now *time.Time) *ApplyCache {
+	t.Helper()
+	c := NewApplyCache()
+	c.now = func() time.Time { return *now }
+	return c
+}
+
+func TestApplyCache_RecordThenUnchanged(t *testing.T) {
+	now := time.Unix(1000, 0)
+	c := testCache(t, &now)
+
+	if c.Unchanged("ns/c1/0", "hashA") {
+		t.Fatal("empty cache reported unchanged; a pod we know nothing about must be applied to")
+	}
+	c.Record("ns/c1/0", "hashA")
+	if !c.Unchanged("ns/c1/0", "hashA") {
+		t.Fatal("recorded hash reported changed")
+	}
+	if c.Unchanged("ns/c1/0", "hashB") {
+		t.Fatal("different hash reported unchanged")
+	}
+	if c.Unchanged("ns/c1/1", "hashA") {
+		t.Fatal("records must not leak between pods of the same cluster")
+	}
+}
+
+// The TTL is the backstop for a pod losing its config without dropping its SSE
+// stream, which nothing else can detect.
+func TestApplyCache_ExpiresAfterRefreshInterval(t *testing.T) {
+	now := time.Unix(1000, 0)
+	c := testCache(t, &now)
+	c.Record("ns/c1/0", "hashA")
+
+	now = now.Add(applyRefreshInterval - time.Second)
+	if !c.Unchanged("ns/c1/0", "hashA") {
+		t.Fatal("expired early")
+	}
+	now = now.Add(2 * time.Second)
+	if c.Unchanged("ns/c1/0", "hashA") {
+		t.Fatal("did not expire at the refresh interval")
+	}
+}
+
+// An SSE disconnect means the pod may have restarted empty. Only that pod's
+// record may be dropped: invalidating its neighbours would re-POST the whole
+// cluster on any single-pod blip.
+func TestApplyCache_InvalidateIsPerPod(t *testing.T) {
+	now := time.Unix(1000, 0)
+	c := testCache(t, &now)
+	c.Record("ns/c1/0", "hashA")
+	c.Record("ns/c1/1", "hashB")
+
+	c.Invalidate("ns/c1/0")
+	if c.Unchanged("ns/c1/0", "hashA") {
+		t.Fatal("invalidated pod still reported unchanged")
+	}
+	if !c.Unchanged("ns/c1/1", "hashB") {
+		t.Fatal("invalidating one pod dropped another")
+	}
+}
+
+func TestApplyCache_InvalidateCluster(t *testing.T) {
+	now := time.Unix(1000, 0)
+	c := testCache(t, &now)
+	c.Record("ns/c1/0", "h")
+	c.Record("ns/c1/1", "h")
+	c.Record("ns/c10/0", "h") // prefix-adjacent, must survive
+	c.Record("ns/c2/0", "h")
+
+	c.InvalidateCluster("ns", "c1")
+	if c.Unchanged("ns/c1/0", "h") || c.Unchanged("ns/c1/1", "h") {
+		t.Fatal("cluster records survived deletion")
+	}
+	if !c.Unchanged("ns/c10/0", "h") {
+		t.Fatal("cluster c10 was dropped by a prefix match on c1")
+	}
+	if !c.Unchanged("ns/c2/0", "h") {
+		t.Fatal("unrelated cluster was dropped")
+	}
+}
+
+// A reconciler built without a cache must apply unconditionally rather than
+// silently skip, so the short-circuit can never be enabled by accident.
+func TestApplyCache_NilIsAlwaysChanged(t *testing.T) {
+	var c *ApplyCache
+	c.Record("ns/c1/0", "hashA")
+	if c.Unchanged("ns/c1/0", "hashA") {
+		t.Fatal("nil cache reported unchanged")
+	}
+	c.Invalidate("ns/c1/0")
+	c.InvalidateCluster("ns", "c1")
+}
+
+// The fingerprint covers the bytes on the wire, so equal payloads compare equal
+// and any difference in what is sent is a difference here.
+func TestFingerprint(t *testing.T) {
+	a := fingerprint([]byte(`{"targets":{}}`))
+	if a != fingerprint([]byte(`{"targets":{}}`)) {
+		t.Fatal("identical bodies produced different fingerprints")
+	}
+	if a == fingerprint([]byte(`{"targets":{"x":null}}`)) {
+		t.Fatal("different bodies produced the same fingerprint")
+	}
+	if a == "" {
+		t.Fatal("empty fingerprint")
+	}
+}

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -71,6 +71,12 @@ type ClusterReconciler struct {
 	// key is namespace/name of the cluster
 	// value is the apply plan for the cluster
 	plans map[string]*gnmic.ApplyPlan
+
+	// Applied records what each pod was last known to hold, so an unchanged
+	// plan is not re-POSTed to every pod on every reconcile. Shared with the
+	// TargetState controller, which invalidates a pod's entry when its SSE
+	// stream drops. Nil disables the short-circuit.
+	Applied *ApplyCache
 }
 
 const (
@@ -767,6 +773,39 @@ func (r *ClusterReconciler) applyConfigToPods(ctx context.Context, cluster *gnmi
 		return fmt.Sprintf("%s://%s:%d/api/v1/config/apply", scheme, podDNS, restPort)
 	}
 
+	// Work out which pods actually need the plan before sending anything. With
+	// the two-phase apply every reconcile otherwise costs 2 x numPods full
+	// config POSTs, each carrying the shared subscriptions/outputs/processors
+	// maps, and all of it is waste when nothing moved.
+	//
+	// Skipping the shrink pass for an unchanged pod is safe: a target moving
+	// from one pod to another changes the desired set of both, so a pod whose
+	// desired set is unchanged is holding no mover for anyone else to wait on.
+	bodies := make(map[int][]byte, numPods)
+	hashes := make(map[int]string, numPods)
+	changed := make(map[int]bool, numPods)
+	anyChanged := false
+	for podIndex := 0; podIndex < numPods; podIndex++ {
+		podPlan, ok := distResult.PerPodPlans[podIndex]
+		if !ok {
+			continue
+		}
+		body, err := json.Marshal(podPlan)
+		if err != nil {
+			return 0, fmt.Errorf("failed to marshal apply plan for pod %d: %w", podIndex, err)
+		}
+		hash := fingerprint(body)
+		bodies[podIndex] = body
+		hashes[podIndex] = hash
+		if !r.Applied.Unchanged(streamKey(cluster.Namespace, cluster.Name, podIndex), hash) {
+			changed[podIndex] = true
+			anyChanged = true
+		}
+	}
+	if !anyChanged {
+		return int32(len(distResult.UnassignedTargets)), nil
+	}
+
 	// Two-phase apply avoids double-collection when a target moves between pods.
 	// A single ordered pass can start the new owner before the old owner has
 	// dropped the target (e.g. moving from pod 2 to pod 0). Phase 1 shrinks
@@ -798,7 +837,7 @@ func (r *ClusterReconciler) applyConfigToPods(ctx context.Context, cluster *gnmi
 		}
 		for podIndex := 0; podIndex < numPods; podIndex++ {
 			podPlan, ok := distResult.PerPodPlans[podIndex]
-			if !ok {
+			if !ok || !changed[podIndex] {
 				continue
 			}
 			shrink := shrinkPodPlan(podPlan, plan.CurrentTargetAssignment[podIndex])
@@ -821,14 +860,17 @@ func (r *ClusterReconciler) applyConfigToPods(ctx context.Context, cluster *gnmi
 
 	for podIndex := 0; podIndex < numPods; podIndex++ {
 		podPlan, ok := distResult.PerPodPlans[podIndex]
-		if !ok {
+		if !ok || !changed[podIndex] {
 			continue
 		}
 		url := podURL(podIndex)
 		logger.Info("sending config to gNMIc pod", "url", url)
-		if err := r.sendApplyRequest(ctx, url, podPlan, httpClient); err != nil {
+		if err := r.sendApplyBody(ctx, url, bodies[podIndex], httpClient); err != nil {
 			return 0, fmt.Errorf("failed to apply config to pod %d: %w", podIndex, err)
 		}
+		// Recorded only after the POST succeeds. Recording the attempt would
+		// make a failed apply look applied until the plan changes again.
+		r.Applied.Record(streamKey(cluster.Namespace, cluster.Name, podIndex), hashes[podIndex])
 		logger.Info("config applied to pod", "pod", podIndex, "targets", len(podPlan.Targets))
 	}
 
@@ -946,15 +988,20 @@ func shrinkPodPlan(podPlan *gnmic.ApplyPlan, previous map[string]struct{}) *gnmi
 	return out
 }
 
-// sendApplyRequest sends an apply plan to a single gNMIc pod
+// sendApplyRequest sends an apply plan to a single gNMIc pod.
 func (r *ClusterReconciler) sendApplyRequest(ctx context.Context, url string, plan *gnmic.ApplyPlan, httpClient *http.Client) error {
-	logger := log.FromContext(ctx)
-
-	// marshal the plan to JSON
 	jsonData, err := json.Marshal(plan)
 	if err != nil {
 		return fmt.Errorf("failed to marshal apply plan: %w", err)
 	}
+	return r.sendApplyBody(ctx, url, jsonData, httpClient)
+}
+
+// sendApplyBody POSTs an already-marshalled plan. The install pass marshals up
+// front to fingerprint the payload, so re-marshalling here would double the
+// cost of the thing this change exists to reduce.
+func (r *ClusterReconciler) sendApplyBody(ctx context.Context, url string, jsonData []byte, httpClient *http.Client) error {
+	logger := log.FromContext(ctx)
 
 	logger.Info("sending config to gNMIc pod", "url", url, "payloadSize", len(jsonData))
 

--- a/internal/controller/cluster_controller_plan.go
+++ b/internal/controller/cluster_controller_plan.go
@@ -36,6 +36,10 @@ func (r *ClusterReconciler) GetClusterPlan(namespace, name string) (*gnmic.Apply
 
 func (r *ClusterReconciler) cleanupPlan(namespace, name string) {
 	r.m.Lock()
-	defer r.m.Unlock()
 	delete(r.plans, namespace+"/"+name)
+	r.m.Unlock()
+	// Per-pod apply records go with the plan, so a deleted cluster does not
+	// leave entries behind, and a cluster recreated under the same name starts
+	// from no assumptions about what its pods hold.
+	r.Applied.InvalidateCluster(namespace, name)
 }

--- a/internal/controller/targetstate_controller.go
+++ b/internal/controller/targetstate_controller.go
@@ -65,6 +65,11 @@ type TargetStateReconciler struct {
 	// streams tracks active SSE goroutines.
 	// Key: "namespace/clusterName/podIndex"
 	streams map[string]context.CancelFunc
+
+	// Applied is the Cluster controller's record of what each pod holds. This
+	// controller is the only component that learns when a pod went away, so it
+	// is the one that invalidates. Nil is valid and disables the coupling.
+	Applied *ApplyCache
 }
 
 // +kubebuilder:rbac:groups=operator.gnmic.dev,resources=clusters,verbs=get;list;watch
@@ -191,6 +196,13 @@ func (r *TargetStateReconciler) runStream(ctx context.Context, cluster *gnmicv1a
 			if receivedEvents {
 				delay = reconnectMinDelay
 			}
+			// The stream ended for a reason other than this operator
+			// cancelling it, so the pod may have restarted and come back
+			// empty. Its recorded configuration can no longer be trusted;
+			// drop it so the next reconcile re-applies to this pod. A blip
+			// that did not restart the pod costs one redundant apply, which
+			// is the direction to err in.
+			r.Applied.Invalidate(streamKey(cluster.Namespace, cluster.Name, podIndex))
 			logger.Info("SSE stream disconnected, reconnecting", "delay", delay)
 			sleepOrDone(ctx, delay)
 			delay = backoff(delay)


### PR DESCRIPTION
The plan was applied to every pod on every reconcile, with nothing comparing it against what those pods already held. The two-phase apply doubled that: a shrink pass and an install pass, so each reconcile cost 2 x numPods full-config POSTs, every one of them carrying the shared subscriptions, outputs and processors maps alongside its targets. All of it waste when nothing moved, and the cost grows with every legitimate reconcile trigger

The record is invalidated by evidence about the pod:

- The TargetState controller already holds a long-lived SSE connection per pod with a reconnect loop, keyed by exactly the tuple the cache needs. A restart kills that connection, and the reconnect path drops that pod's record and only that pod's. No pod informer, no RBAC change; the signal was already there. Streams this operator cancels deliberately exit through ctx.Done() and do not invalidate.
- A record is written only after the POST succeeds. Recording the attempt would make a failed apply look applied until the plan next changed.
- Deleting a cluster drops its pod records, so one recreated under the same name starts from no assumptions.