### PR TITLE
refactor: enhance subscription handling and improve resource management

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -377,7 +377,11 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 		for _, subscription := range subscriptions {
-			pipelineData.Subscriptions[subscription.Namespace+gnmic.Delimiter+subscription.Name] = subscription.Spec
+			// Key by pipeline like outputs so two pipelines sharing one
+			// Subscription CR each get their own output binding. A flat
+			// namespace/name key merges both pipelines' outputs onto every
+			// target that uses the subscription.
+			pipelineData.Subscriptions[pipelineNN+gnmic.Delimiter+subscription.Name] = subscription.Spec
 		}
 		logger.Info("cluster pipeline resolved subscriptions", "count", len(subscriptions))
 
@@ -1490,11 +1494,29 @@ func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, cluster *g
 		needsUpdate = true
 	}
 
-	// update volumes if they changed (needed when scaling with TLS enabled)
+	// update volumes if they changed (needed when scaling with TLS enabled, or
+	// when clientTLS / api.tls / tunnel TLS is added or removed after create)
 	// projected volumes include per-pod certificate secrets, so they change when replicas change
 	if !volumesEqual(current.Spec.Template.Spec.Volumes, desired.Spec.Template.Spec.Volumes) {
 		current.Spec.Template.Spec.Volumes = desired.Spec.Template.Spec.Volumes
 		needsUpdate = true
+	}
+
+	// volumeMounts (and the Env they depend on, e.g. POD_NAME for subPathExpr)
+	// must stay in lockstep with volumes — otherwise enabling clientTLS/api.tls
+	// on a live Cluster adds Secret/ConfigMap volumes that are never mounted,
+	// or mounts that fail with CreateContainerConfigError.
+	if len(desired.Spec.Template.Spec.Containers) > 0 && len(current.Spec.Template.Spec.Containers) > 0 {
+		desiredCtr := &desired.Spec.Template.Spec.Containers[0]
+		currentCtr := &current.Spec.Template.Spec.Containers[0]
+		if !volumeMountsEqual(currentCtr.VolumeMounts, desiredCtr.VolumeMounts) {
+			currentCtr.VolumeMounts = desiredCtr.VolumeMounts
+			needsUpdate = true
+		}
+		if !envVarsEqual(currentCtr.Env, desiredCtr.Env) {
+			currentCtr.Env = desiredCtr.Env
+			needsUpdate = true
+		}
 	}
 
 	if needsUpdate {
@@ -1529,6 +1551,54 @@ func volumesEqual(a, b []corev1.Volume) bool {
 				return false
 			}
 		} else if (va.Projected == nil) != (vb.Projected == nil) {
+			return false
+		}
+		// secret / configMap volume identity (clientTLS, CA bundles)
+		if (va.Secret == nil) != (vb.Secret == nil) {
+			return false
+		}
+		if va.Secret != nil && vb.Secret != nil && va.Secret.SecretName != vb.Secret.SecretName {
+			return false
+		}
+		if (va.ConfigMap == nil) != (vb.ConfigMap == nil) {
+			return false
+		}
+		if va.ConfigMap != nil && vb.ConfigMap != nil && va.ConfigMap.Name != vb.ConfigMap.Name {
+			return false
+		}
+	}
+	return true
+}
+
+// volumeMountsEqual compares mount name+path pairs.
+func volumeMountsEqual(a, b []corev1.VolumeMount) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	type key struct{ name, path, sub string }
+	aSet := make(map[key]struct{}, len(a))
+	for _, m := range a {
+		aSet[key{m.Name, m.MountPath, m.SubPathExpr}] = struct{}{}
+	}
+	for _, m := range b {
+		if _, ok := aSet[key{m.Name, m.MountPath, m.SubPathExpr}]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// envVarsEqual compares env var names (value/valueFrom identity ignored beyond presence).
+func envVarsEqual(a, b []corev1.EnvVar) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aNames := make(map[string]struct{}, len(a))
+	for _, e := range a {
+		aNames[e.Name] = struct{}{}
+	}
+	for _, e := range b {
+		if _, ok := aNames[e.Name]; !ok {
 			return false
 		}
 	}
@@ -3567,20 +3637,8 @@ func (r *ClusterReconciler) reconcilePrometheusService(ctx context.Context, clus
 
 // buildPrometheusService builds a service for a Prometheus output
 func (r *ClusterReconciler) buildPrometheusService(cluster *gnmicv1alpha1.Cluster, serviceName, outputName, pipelineName string, port int32, urlPath string, outputSpec *gnmicv1alpha1.OutputSpec) *corev1.Service {
-	labels := map[string]string{
-		"app.kubernetes.io/name":       LabelValueName,
-		"app.kubernetes.io/managed-by": LabelValueManagedBy,
-		LabelClusterName:               cluster.Name,
-		LabelServiceType:               LabelValueOutputTypePrometheus,
-		LabelOutputName:                outputName,
-		LabelPipelineName:              pipelineName,
-	}
-
-	annotations := map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   strconv.Itoa(int(port)),
-		"prometheus.io/path":   urlPath,
-	}
+	labels := map[string]string{}
+	annotations := map[string]string{}
 	// default to ClusterIP if no service config is provided
 	serviceType := corev1.ServiceTypeClusterIP
 
@@ -3595,6 +3653,18 @@ func (r *ClusterReconciler) buildPrometheusService(cluster *gnmicv1alpha1.Cluste
 			maps.Copy(labels, outputSpec.Service.Labels)
 		}
 	}
+
+	// Operator labels and scrape annotations win over user-supplied keys with
+	// the same name so ServiceMonitors and GC ownership stay reliable.
+	labels["app.kubernetes.io/name"] = LabelValueName
+	labels["app.kubernetes.io/managed-by"] = LabelValueManagedBy
+	labels[LabelClusterName] = cluster.Name
+	labels[LabelServiceType] = LabelValueServiceTypePrometheusOutput
+	labels[LabelOutputName] = outputName
+	labels[LabelPipelineName] = pipelineName
+	annotations["prometheus.io/scrape"] = "true"
+	annotations["prometheus.io/port"] = strconv.Itoa(int(port))
+	annotations["prometheus.io/path"] = urlPath
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3644,12 +3714,13 @@ type listenPortAndPath struct {
 	Path   string `yaml:"path,omitempty" json:"path,omitempty"`
 }
 
-// parseListenPortAndPath parses the "listen" and "path" fields from output config and returns the port and path.
-// supports formats: "listen: ":9804", "0.0.0.0:9804", "localhost:9804", "[::1]:9804", "[2001:db8::8a2e:370:7334]:9804".
-// returns the default port 9804 if not specified.
-// returns the default path /metrics if not specified.
+// parseListenPortAndPath parses the "listen" and "path" fields from output config.
+// Supports: ":9804", "0.0.0.0:9804", "localhost:9804", "[::1]:9804".
+// When listen is unset, port is 0 so callers can use the plan-assigned port
+// from assignPrometheusOutputPorts — do not invent PrometheusDefaultPort here
+// or the Service will disagree with the collector's actual listen address.
 func parseListenPortAndPath(configRaw []byte) (int32, string, error) {
-	if configRaw == nil {
+	if len(configRaw) == 0 {
 		return 0, "", nil
 	}
 
@@ -3658,16 +3729,12 @@ func parseListenPortAndPath(configRaw []byte) (int32, string, error) {
 		return 0, "", err
 	}
 
+	config.Path = strings.TrimSpace(config.Path)
 	config.Listen = strings.TrimSpace(config.Listen)
 	if config.Listen == "" {
-		config.Listen = fmt.Sprintf(":%d", gnmic.PrometheusDefaultPort)
-	}
-	config.Path = strings.TrimSpace(config.Path)
-	if config.Path == "" {
-		config.Path = gnmic.PrometheusDefaultPath
+		return 0, config.Path, nil
 	}
 
-	// parse the port from the listen string value
 	idx := strings.LastIndex(config.Listen, ":")
 	if idx == -1 {
 		return 0, "", fmt.Errorf("invalid listen format: %s", config.Listen)

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -52,13 +52,18 @@ func TestPipelineReferencesResource(t *testing.T) {
 
 func TestParseListenPortAndPath(t *testing.T) {
 	port, path, err := parseListenPortAndPath([]byte(`listen: ":9805"`))
-	if err != nil || port != 9805 || path != "/metrics" {
+	if err != nil || port != 9805 || path != "" {
 		t.Fatalf("port=%d path=%q err=%v", port, path, err)
 	}
 
 	port, path, err = parseListenPortAndPath([]byte("listen: \"127.0.0.1:8080\"\npath: /custom\n"))
 	if err != nil || port != 8080 || path != "/custom" {
 		t.Fatalf("port=%d path=%q err=%v", port, path, err)
+	}
+
+	port, path, err = parseListenPortAndPath([]byte(`{}`))
+	if err != nil || port != 0 || path != "" {
+		t.Fatalf("empty config: port=%d path=%q err=%v", port, path, err)
 	}
 
 	if _, _, err := parseListenPortAndPath([]byte("not yaml")); err == nil {

--- a/internal/gnmic/config_builders_test.go
+++ b/internal/gnmic/config_builders_test.go
@@ -164,13 +164,21 @@ func TestConvert(t *testing.T) {
 
 func TestBuildSubscriptionConfig(t *testing.T) {
 	spec := &gnmicv1alpha1.SubscriptionSpec{
-		Prefix: "/interfaces",
-		Paths:  []string{"/interfaces/interface"},
-		Mode:   "STREAM/SAMPLE",
+		Prefix:            "/interfaces",
+		Paths:             []string{"/interfaces/interface"},
+		Mode:              "STREAM/SAMPLE",
+		SuppressRedundant: true,
+		UpdatesOnly:       true,
 	}
 	cfg := buildSubscriptionConfig("default/sub1", spec, []string{"default/out1"}, nil)
 	if cfg.Mode != "STREAM" || cfg.StreamMode != "SAMPLE" {
 		t.Fatalf("mode = %s/%s", cfg.Mode, cfg.StreamMode)
+	}
+	if !cfg.SuppressRedundant {
+		t.Fatal("expected SuppressRedundant")
+	}
+	if !cfg.UpdatesOnly {
+		t.Fatal("expected UpdatesOnly")
 	}
 
 	mode, stream := specModeToConfig("ONCE")

--- a/internal/gnmic/plan.go
+++ b/internal/gnmic/plan.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log/slog"
-	"maps"
 	"os"
 	"sort"
 	"strconv"
@@ -144,10 +143,12 @@ func (b *PlanBuilder) Build() (*ApplyPlan, error) {
 		if err := b.buildTunnelTargetMatches(plan, pipelineData); err != nil {
 			return nil, err
 		}
-		// 2.7) assign prometheus output ports
-		if err := b.assignPrometheusOutputPorts(plan, pipelineData); err != nil {
-			return nil, err
-		}
+	}
+
+	// Assign Prometheus listen ports across the whole plan so two pipelines
+	// sharing (or each having) a prometheus output cannot both land on :9804.
+	if err := b.assignPrometheusOutputPorts(plan); err != nil {
+		return nil, err
 	}
 
 	return plan, nil
@@ -218,36 +219,38 @@ func (b *PlanBuilder) collectRelationships(plan *ApplyPlan) {
 			}
 		}
 		// output -> processors
-		// ordered relationship between outputs and their processors.
-		// builds map[outputNN][]processorNN where the slice maintains the order from the pipeline.
-		processorNames := make([]string, 0, len(pipelineData.OutputProcessors))
-		for processorNN := range pipelineData.OutputProcessors {
-			processorNames = append(processorNames, processorNN)
+		// Prefer OutputProcessorOrder (refs then sorted selectors). Fall back to
+		// sorted map keys for callers that only populate the map.
+		processorNames := pipelineData.OutputProcessorOrder
+		if len(processorNames) == 0 {
+			processorNames = make([]string, 0, len(pipelineData.OutputProcessors))
+			for processorNN := range pipelineData.OutputProcessors {
+				processorNames = append(processorNames, processorNN)
+			}
+			sort.Strings(processorNames)
 		}
 
 		for outputNN := range pipelineData.Outputs {
 			if _, ok := b.relationships.outputProcessors[outputNN]; !ok {
 				b.relationships.outputProcessors[outputNN] = make([]string, 0)
 			}
-			for _, processorName := range processorNames {
-				b.relationships.outputProcessors[outputNN] = append(b.relationships.outputProcessors[outputNN], processorName)
-			}
+			b.relationships.outputProcessors[outputNN] = append(b.relationships.outputProcessors[outputNN], processorNames...)
 		}
 		// input -> processors
-		// ordered relationship between inputs and their processors.
-		// builds map[inputNN][]processorNN where the slice maintains the order from the pipeline.
-		inputProcessorNames := make([]string, 0, len(pipelineData.InputProcessors))
-		for processorNN := range pipelineData.InputProcessors {
-			inputProcessorNames = append(inputProcessorNames, processorNN)
+		inputProcessorNames := pipelineData.InputProcessorOrder
+		if len(inputProcessorNames) == 0 {
+			inputProcessorNames = make([]string, 0, len(pipelineData.InputProcessors))
+			for processorNN := range pipelineData.InputProcessors {
+				inputProcessorNames = append(inputProcessorNames, processorNN)
+			}
+			sort.Strings(inputProcessorNames)
 		}
 
 		for inputNN := range pipelineData.Inputs {
 			if _, ok := b.relationships.inputProcessors[inputNN]; !ok {
 				b.relationships.inputProcessors[inputNN] = make([]string, 0)
 			}
-			for _, processorName := range inputProcessorNames {
-				b.relationships.inputProcessors[inputNN] = append(b.relationships.inputProcessors[inputNN], processorName)
-			}
+			b.relationships.inputProcessors[inputNN] = append(b.relationships.inputProcessors[inputNN], inputProcessorNames...)
 		}
 	}
 }
@@ -471,23 +474,24 @@ func (b *PlanBuilder) buildTunnelTargetMatches(plan *ApplyPlan, pipelineData *Pi
 	return nil
 }
 
-func (b *PlanBuilder) assignPrometheusOutputPorts(plan *ApplyPlan, pipelineData *PipelineData) error {
+func (b *PlanBuilder) assignPrometheusOutputPorts(plan *ApplyPlan) error {
 	promoutputs := make([]string, 0)
-	for outputNN, outputSpec := range pipelineData.Outputs {
-		if outputSpec.Type != PrometheusOutputType {
-			continue
+	for outputNN, cfg := range plan.Outputs {
+		if t, _ := cfg["type"].(string); t == PrometheusOutputType {
+			promoutputs = append(promoutputs, outputNN)
 		}
-		promoutputs = append(promoutputs, outputNN)
 	}
-	pipelinePortMap, err := assignPorts(promoutputs, PrometheusDefaultPort, PrmetheusPortPoolSize)
+	if len(promoutputs) == 0 {
+		return nil
+	}
+	portMap, err := assignPorts(promoutputs, PrometheusDefaultPort, PrmetheusPortPoolSize)
 	if err != nil {
 		return err
 	}
-	maps.Copy(plan.PrometheusPorts, pipelinePortMap)
-	for outputPNN, port := range pipelinePortMap {
+	plan.PrometheusPorts = portMap
+	for outputPNN, port := range portMap {
 		plan.Outputs[outputPNN]["listen"] = fmt.Sprintf(":%d", port)
 	}
-
 	return nil
 }
 

--- a/internal/gnmic/plan_test.go
+++ b/internal/gnmic/plan_test.go
@@ -129,6 +129,74 @@ func TestAssignPorts(t *testing.T) {
 	}
 }
 
+func TestAssignPrometheusPortsDistinctAcrossPipelines(t *testing.T) {
+	sub := gnmicv1alpha1.SubscriptionSpec{Paths: []string{"/"}, Mode: "ONCE"}
+	p1 := NewPipelineData()
+	p1.Subscriptions["ns/p1/sub"] = sub
+	p1.Outputs["ns/p1/out1"] = gnmicv1alpha1.OutputSpec{Type: PrometheusOutputType}
+	p2 := NewPipelineData()
+	p2.Subscriptions["ns/p2/sub"] = sub
+	p2.Outputs["ns/p2/out1"] = gnmicv1alpha1.OutputSpec{Type: PrometheusOutputType}
+
+	plan, err := NewPlanBuilder("c", nil).AddPipeline("p1", p1).AddPipeline("p2", p2).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, b := plan.PrometheusPorts["ns/p1/out1"], plan.PrometheusPorts["ns/p2/out1"]
+	if a == 0 || b == 0 {
+		t.Fatalf("missing ports: %v", plan.PrometheusPorts)
+	}
+	if a == b {
+		t.Fatalf("pipelines collided on port %d", a)
+	}
+}
+
+func TestSharedSubscriptionKeepsPerPipelineOutputs(t *testing.T) {
+	profile := gnmicv1alpha1.TargetProfileSpec{Encoding: "JSON"}
+	sub := gnmicv1alpha1.SubscriptionSpec{Paths: []string{"/"}, Mode: "ONCE"}
+
+	p1 := NewPipelineData()
+	p1.TargetProfiles["default/default"] = profile
+	p1.Targets["default/leaf1"] = gnmicv1alpha1.Target{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "leaf1"},
+		Spec:       gnmicv1alpha1.TargetSpec{Address: "10.0.0.1:57400", Profile: "default"},
+	}
+	p1.Subscriptions["default/p1/sub"] = sub
+	p1.Outputs["default/p1/out"] = gnmicv1alpha1.OutputSpec{Type: FileOutputType}
+
+	p2 := NewPipelineData()
+	p2.TargetProfiles["default/default"] = profile
+	p2.Targets["default/spine1"] = gnmicv1alpha1.Target{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "spine1"},
+		Spec:       gnmicv1alpha1.TargetSpec{Address: "10.0.0.2:57400", Profile: "default"},
+	}
+	p2.Subscriptions["default/p2/sub"] = sub
+	p2.Outputs["default/p2/out"] = gnmicv1alpha1.OutputSpec{Type: FileOutputType}
+
+	plan, err := NewPlanBuilder("c", &mockCredsFetcher{}).
+		AddPipeline("p1", p1).
+		AddPipeline("p2", p2).
+		Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leafSubs := plan.Targets["default/leaf1"].Subscriptions
+	spineSubs := plan.Targets["default/spine1"].Subscriptions
+	if len(leafSubs) != 1 || leafSubs[0] != "default/p1/sub" {
+		t.Fatalf("leaf subscriptions = %v", leafSubs)
+	}
+	if len(spineSubs) != 1 || spineSubs[0] != "default/p2/sub" {
+		t.Fatalf("spine subscriptions = %v", spineSubs)
+	}
+	if outs := plan.Subscriptions["default/p1/sub"].Outputs; len(outs) != 1 || outs[0] != "default/p1/out" {
+		t.Fatalf("p1 sub outputs = %v", outs)
+	}
+	if outs := plan.Subscriptions["default/p2/sub"].Outputs; len(outs) != 1 || outs[0] != "default/p2/out" {
+		t.Fatalf("p2 sub outputs = %v", outs)
+	}
+}
+
 func TestHash32(t *testing.T) {
 	if hash32("x") == hash32("y") {
 		t.Fatal("expected different hashes")

--- a/internal/gnmic/subscription.go
+++ b/internal/gnmic/subscription.go
@@ -13,15 +13,16 @@ func buildSubscriptionConfig(subNN string, subscription *gnmicv1alpha1.Subscript
 	mode, streamMode := specModeToConfig(subscription.Mode)
 
 	config := &gapi.SubscriptionConfig{
-		Name:        subNN,
-		Prefix:      subscription.Prefix,
-		Paths:       subscription.Paths,
-		Mode:        mode,
-		StreamMode:  streamMode,
-		UpdatesOnly: subscription.UpdatesOnly,
-		Depth:       subscription.Depth,
-		Target:      subscription.Target,
-		Outputs:     outputs,
+		Name:              subNN,
+		Prefix:            subscription.Prefix,
+		Paths:             subscription.Paths,
+		Mode:              mode,
+		StreamMode:        streamMode,
+		UpdatesOnly:       subscription.UpdatesOnly,
+		SuppressRedundant: subscription.SuppressRedundant,
+		Depth:             subscription.Depth,
+		Target:            subscription.Target,
+		Outputs:           outputs,
 	}
 
 	if len(outputs) > 0 {

--- a/test/integration/harness/exec.go
+++ b/test/integration/harness/exec.go
@@ -21,6 +21,16 @@ import (
 // ConfigMap says it should have.
 func (k *K8s) Exec(t *testing.T, pod, container string, command ...string) string {
 	t.Helper()
+	out, err := k.ExecQuiet(pod, container, command...)
+	if err != nil {
+		t.Fatalf("exec %v in %s: %v", command, pod, err)
+	}
+	return out
+}
+
+// ExecQuiet is Exec without failing the test — for poll loops during rollouts
+// when the container may be briefly unavailable.
+func (k *K8s) ExecQuiet(pod, container string, command ...string) (string, error) {
 	req := k.Clientset.CoreV1().RESTClient().
 		Post().
 		Resource("pods").
@@ -36,14 +46,14 @@ func (k *K8s) Exec(t *testing.T, pod, container string, command ...string) strin
 
 	exec, err := remotecommand.NewSPDYExecutor(k.RestCfg, http.MethodPost, req.URL())
 	if err != nil {
-		t.Fatalf("building executor for %s: %v", pod, err)
+		return "", fmt.Errorf("building executor: %w", err)
 	}
 	var stdout, stderr bytes.Buffer
 	err = exec.StreamWithContext(k.Ctx, remotecommand.StreamOptions{Stdout: &stdout, Stderr: &stderr})
 	if err != nil {
-		t.Fatalf("exec %v in %s: %v (stderr: %s)", command, pod, err, stderr.String())
+		return stdout.String(), fmt.Errorf("%w (stderr: %s)", err, stderr.String())
 	}
-	return stdout.String()
+	return stdout.String(), nil
 }
 
 // CollectorAPI opens a port-forward to a collector pod's REST API and returns a

--- a/test/integration/harness/file.go
+++ b/test/integration/harness/file.go
@@ -1,0 +1,169 @@
+//go:build integration
+
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// CollectorContainer is the container name in collector pods.
+const CollectorContainer = "gnmic"
+
+// FirstCollectorPod returns the name of the first ready collector pod for cluster.
+func (k *K8s) FirstCollectorPod(t *testing.T, cluster string) string {
+	t.Helper()
+	pods := k.ClusterPods(t, cluster)
+	for i := range pods {
+		if podReady(&pods[i]) {
+			return pods[i].Name
+		}
+	}
+	t.Fatalf("no ready collector pod for cluster %s", cluster)
+	return ""
+}
+
+// ReadCollectorFile returns the contents of path inside the first ready
+// collector pod. Missing files yield an empty string rather than failing, so
+// callers can poll.
+func (k *K8s) ReadCollectorFile(t *testing.T, cluster, path string) string {
+	t.Helper()
+	pod := k.FirstCollectorPod(t, cluster)
+	out := k.Exec(t, pod, CollectorContainer, "sh", "-c", fmt.Sprintf("cat %q 2>/dev/null || true", path))
+	return out
+}
+
+// WaitCollectorFileNonEmpty polls until the file inside the collector is non-empty.
+func (k *K8s) WaitCollectorFileNonEmpty(t *testing.T, cluster, path string) string {
+	t.Helper()
+	var body string
+	Wait(t, Medium, fmt.Sprintf("collector file %s non-empty", path), func() (bool, string) {
+		body = k.ReadCollectorFile(t, cluster, path)
+		if strings.TrimSpace(body) == "" {
+			return false, "empty"
+		}
+		return true, ""
+	})
+	return body
+}
+
+// WaitCollectorFileGrows waits until the file's byte length increases past floor.
+func (k *K8s) WaitCollectorFileGrows(t *testing.T, cluster, path string, floor int) string {
+	t.Helper()
+	var body string
+	Wait(t, Medium, fmt.Sprintf("collector file %s grows past %d", path, floor), func() (bool, string) {
+		body = k.ReadCollectorFile(t, cluster, path)
+		if len(body) > floor {
+			return true, ""
+		}
+		return false, fmt.Sprintf("len=%d", len(body))
+	})
+	return body
+}
+
+// EventMsg is one gnmic event-format record as written by a file output.
+type EventMsg struct {
+	Name      string            `json:"name"`
+	Timestamp int64             `json:"timestamp"`
+	Tags      map[string]string `json:"tags"`
+	Values    map[string]any    `json:"values"`
+}
+
+// ParseEvents extracts EventMsg values from a file-output body. Lines may be
+// single objects or JSON arrays of objects.
+func ParseEvents(body string) []EventMsg {
+	var out []EventMsg
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var one EventMsg
+		if err := json.Unmarshal([]byte(line), &one); err == nil && (one.Tags != nil || one.Values != nil || one.Name != "") {
+			out = append(out, one)
+			continue
+		}
+		var many []EventMsg
+		if err := json.Unmarshal([]byte(line), &many); err == nil {
+			out = append(out, many...)
+		}
+	}
+	return out
+}
+
+// EventsHaveTag reports whether any event carries tags[key]=value.
+func EventsHaveTag(events []EventMsg, key, value string) bool {
+	for _, e := range events {
+		if e.Tags != nil && e.Tags[key] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// EventsHaveSource reports whether any event's tags identify source (substring match).
+func EventsHaveSource(events []EventMsg, source string) bool {
+	for _, e := range events {
+		if e.Tags == nil {
+			continue
+		}
+		for _, v := range e.Tags {
+			if strings.Contains(v, source) {
+				return true
+			}
+		}
+		if src, ok := e.Tags["source"]; ok && strings.Contains(src, source) {
+			return true
+		}
+	}
+	return false
+}
+
+// WaitEventsHaveTag polls the collector file until an event carries the tag.
+func (k *K8s) WaitEventsHaveTag(t *testing.T, cluster, path, key, value string) []EventMsg {
+	t.Helper()
+	var events []EventMsg
+	Wait(t, Medium, fmt.Sprintf("events with %s=%s in %s", key, value, path), func() (bool, string) {
+		events = ParseEvents(k.ReadCollectorFile(t, cluster, path))
+		if EventsHaveTag(events, key, value) {
+			return true, ""
+		}
+		return false, fmt.Sprintf("%d events", len(events))
+	})
+	return events
+}
+
+// WaitEventsHaveSources polls until every named source appears in the file.
+func (k *K8s) WaitEventsHaveSources(t *testing.T, cluster, path string, sources ...string) []EventMsg {
+	t.Helper()
+	var events []EventMsg
+	Wait(t, Medium, fmt.Sprintf("events from %v in %s", sources, path), func() (bool, string) {
+		events = ParseEvents(k.ReadCollectorFile(t, cluster, path))
+		missing := make([]string, 0)
+		for _, src := range sources {
+			if !EventsHaveSource(events, src) {
+				missing = append(missing, src)
+			}
+		}
+		if len(missing) == 0 {
+			return true, ""
+		}
+		return false, fmt.Sprintf("missing=%v events=%d", missing, len(events))
+	})
+	return events
+}
+
+// ConsistentlyEventsLackTag fails if any sample in the window carries the tag.
+func (k *K8s) ConsistentlyEventsLackTag(t *testing.T, cluster, path, key, value string, dur time.Duration) {
+	t.Helper()
+	Consistently(t, dur, time.Second, fmt.Sprintf("no events with %s=%s", key, value), func() (bool, string) {
+		events := ParseEvents(k.ReadCollectorFile(t, cluster, path))
+		if EventsHaveTag(events, key, value) {
+			return false, "tag present"
+		}
+		return true, ""
+	})
+}

--- a/test/integration/harness/k8s.go
+++ b/test/integration/harness/k8s.go
@@ -254,6 +254,13 @@ func (k *K8s) Target(t *testing.T, name string) *gnmicv1alpha1.Target {
 	return o
 }
 
+func (k *K8s) TargetProfile(t *testing.T, name string) *gnmicv1alpha1.TargetProfile {
+	t.Helper()
+	o := &gnmicv1alpha1.TargetProfile{}
+	k.get(t, name, o)
+	return o
+}
+
 // WaitExists blocks until a named object exists, then leaves it in obj.
 func (k *K8s) WaitExists(t *testing.T, name string, obj client.Object) {
 	t.Helper()
@@ -444,6 +451,63 @@ func AssertNoPanics(t *testing.T, logs string) {
 	if strings.Contains(logs, "panic: ") || strings.Contains(logs, "runtime error:") {
 		t.Fatalf("panic found in logs:\n%s", logs)
 	}
+}
+
+// Operator deployment in gnmic-system. Suites that restart it (008-12) must
+// run alone or last: a restart affects every suite sharing the cluster.
+const (
+	OperatorNamespace  = "gnmic-system"
+	OperatorDeployment = "gnmic-controller-manager"
+)
+
+// RestartOperator rolls the controller-manager Deployment and waits until a
+// new pod is Ready. Touches cluster-global state outside the suite namespace.
+func (k *K8s) RestartOperator(t *testing.T) {
+	t.Helper()
+	before := map[types.UID]struct{}{}
+	for _, p := range k.OperatorPods(t) {
+		before[p.UID] = struct{}{}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), Long)
+	defer cancel()
+	deploy, err := k.Clientset.AppsV1().Deployments(OperatorNamespace).Get(ctx, OperatorDeployment, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting operator deployment: %v", err)
+	}
+	if deploy.Spec.Template.Annotations == nil {
+		deploy.Spec.Template.Annotations = map[string]string{}
+	}
+	deploy.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+	if _, err := k.Clientset.AppsV1().Deployments(OperatorNamespace).Update(ctx, deploy, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("restarting operator: %v", err)
+	}
+
+	Wait(t, Long, "operator rollout complete", func() (bool, string) {
+		d, err := k.Clientset.AppsV1().Deployments(OperatorNamespace).Get(context.Background(), OperatorDeployment, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		if d.Status.UpdatedReplicas < 1 || d.Status.ReadyReplicas < 1 ||
+			d.Status.UnavailableReplicas > 0 || d.Status.ObservedGeneration < d.Generation {
+			return false, fmt.Sprintf("updated=%d ready=%d unavailable=%d gen=%d/%d",
+				d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.UnavailableReplicas,
+				d.Status.ObservedGeneration, d.Generation)
+		}
+		pods, err := k.listOperatorPods()
+		if err != nil {
+			return false, err.Error()
+		}
+		for _, p := range pods {
+			if !podReady(&p) {
+				continue
+			}
+			if _, old := before[p.UID]; !old {
+				return true, ""
+			}
+		}
+		return false, "no new ready operator pod yet"
+	})
 }
 
 // OperatorPods lists controller-manager pods in gnmic-system.

--- a/test/integration/harness/manifests/gnmi-gen.yaml
+++ b/test/integration/harness/manifests/gnmi-gen.yaml
@@ -48,6 +48,11 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
+{{- if .TLSSecret }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+{{- end }}
           readinessProbe:
             httpGet:
               path: /api/v1/targets
@@ -66,3 +71,8 @@ spec:
         - name: config
           configMap:
             name: gnmi-gen-config
+{{- if .TLSSecret }}
+        - name: tls
+          secret:
+            secretName: {{ .TLSSecret }}
+{{- end }}

--- a/test/integration/harness/names.go
+++ b/test/integration/harness/names.go
@@ -36,6 +36,12 @@ func HeadlessServiceName(cluster string) string { return resourcePrefix + cluste
 func ConfigMapName(cluster string) string       { return resourcePrefix + cluster + "-config" }
 func TunnelServiceName(cluster string) string   { return resourcePrefix + cluster + "-grpc-tunnel" }
 func ClientCertName(cluster string) string      { return resourcePrefix + cluster + "-client-tls" }
+func APICertName(cluster string, ordinal int) string {
+	return fmt.Sprintf("%s%s-%d-tls", resourcePrefix, cluster, ordinal)
+}
+func ControllerCAConfigMap(cluster string) string {
+	return resourcePrefix + cluster + "-controller-ca"
+}
 
 func PromServiceName(cluster, pipeline, output string) string {
 	return fmt.Sprintf("%s%s-prom-%s-%s", resourcePrefix, cluster, pipeline, output)

--- a/test/integration/harness/prom.go
+++ b/test/integration/harness/prom.go
@@ -14,6 +14,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var labelValueRE = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_]*)="([^"]*)"`)
@@ -158,23 +159,70 @@ func (k *K8s) PromListenPort(t *testing.T, service string) int {
 // forward) and returns the concatenated body.
 func (k *K8s) ScrapeClusterPrometheus(t *testing.T, cluster, pipeline, output string) string {
 	t.Helper()
+	body, err := k.ScrapeClusterPrometheusQuiet(cluster, pipeline, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+// ScrapeClusterPrometheusQuiet is the non-fatal form for polling helpers.
+func (k *K8s) ScrapeClusterPrometheusQuiet(cluster, pipeline, output string) (string, error) {
+	return k.scrapeClusterPrometheus(cluster, pipeline, output)
+}
+
+func (k *K8s) scrapeClusterPrometheus(cluster, pipeline, output string) (string, error) {
 	svc := PromServiceName(cluster, pipeline, output)
-	port := k.PromListenPort(t, svc)
+	var svcObj corev1.Service
+	if err := k.Client.Get(k.Ctx, types.NamespacedName{Namespace: k.Namespace, Name: svc}, &svcObj); err != nil {
+		return "", fmt.Errorf("getting prometheus service %s: %w", svc, err)
+	}
+	if len(svcObj.Spec.Ports) == 0 {
+		return "", fmt.Errorf("prometheus service %s has no ports", svc)
+	}
+	port := int(svcObj.Spec.Ports[0].Port)
+
+	var list corev1.PodList
+	if err := k.Client.List(k.Ctx, &list,
+		client.InNamespace(k.Namespace),
+		client.MatchingLabels{LabelClusterName: cluster}); err != nil {
+		return "", fmt.Errorf("listing collector pods: %w", err)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
 	var b strings.Builder
-	for _, pod := range k.ClusterPods(t, cluster) {
-		if !podReady(&pod) {
+	scraped := 0
+	for i := range list.Items {
+		pod := &list.Items[i]
+		if !podReady(pod) {
 			continue
 		}
 		fw, err := k.ForwardPodPort(pod.Name, port)
 		if err != nil {
-			t.Fatalf("port-forward %s:%d: %v", pod.Name, port, err)
+			return "", fmt.Errorf("port-forward %s:%d: %w", pod.Name, port, err)
 		}
-		body := Scrape(t, fw.URL+"/metrics")
+		resp, err := client.Get(fw.URL + "/metrics")
+		if err != nil {
+			fw.Close()
+			return "", fmt.Errorf("scraping %s: %w", fw.URL+"/metrics", err)
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
 		fw.Close()
-		b.WriteString(body)
+		if err != nil {
+			return "", err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("scraping %s: %s", fw.URL+"/metrics", resp.Status)
+		}
+		b.Write(body)
 		b.WriteByte('\n')
+		scraped++
 	}
-	return b.String()
+	if scraped == 0 {
+		return "", fmt.Errorf("no ready collector pods to scrape for %s", svc)
+	}
+	return b.String(), nil
 }
 
 // WaitClusterPrometheusSources waits until the union of source label values
@@ -182,7 +230,10 @@ func (k *K8s) ScrapeClusterPrometheus(t *testing.T, cluster, pipeline, output st
 func (k *K8s) WaitClusterPrometheusSources(t *testing.T, cluster, pipeline, output string, want []string, timeout time.Duration) {
 	t.Helper()
 	Wait(t, timeout, fmt.Sprintf("prometheus sources for %d targets", len(want)), func() (bool, string) {
-		body := k.ScrapeClusterPrometheus(t, cluster, pipeline, output)
+		body, err := k.ScrapeClusterPrometheusQuiet(cluster, pipeline, output)
+		if err != nil {
+			return false, err.Error()
+		}
 		sources := LabelValues(body, "source")
 		missing := 0
 		for _, w := range want {

--- a/test/integration/harness/suite.go
+++ b/test/integration/harness/suite.go
@@ -55,6 +55,10 @@ type Options struct {
 	// RequireTargets are simulated targets that must report "up" before tests
 	// start.
 	RequireTargets []string
+	// BeforeGnmiGen runs after the namespace exists and before the simulator is
+	// deployed. Used by suites that must stage Secrets (e.g. TLS server certs)
+	// for gnmi-gen to mount at startup.
+	BeforeGnmiGen func(*Suite) error
 	// AfterBaseline runs after baseline fixtures are applied, before m.Run.
 	// Used by suites that generate large numbers of CRs (e.g. 013-scale).
 	AfterBaseline func(*Suite) error
@@ -68,6 +72,10 @@ type Suite struct {
 	K8s       *K8s
 	GnmiGen   *GnmiGen
 	Ctx       context.Context
+
+	// GnmiGenTLSSecret, when set before deployGnmiGen, mounts that Secret at
+	// /tls inside the simulator pod (tls.crt / tls.key).
+	GnmiGenTLSSecret string
 
 	forward *Forward
 	cancel  context.CancelFunc
@@ -98,6 +106,12 @@ func New(opts Options) (*Suite, error) {
 		return nil, fmt.Errorf("creating namespace: %w", err)
 	}
 	logf("suite %s: namespace %s ready", opts.Name, namespace)
+
+	if opts.BeforeGnmiGen != nil {
+		if err := opts.BeforeGnmiGen(s); err != nil {
+			return s, fmt.Errorf("before gnmi-gen: %w", err)
+		}
+	}
 
 	if err := s.deployGnmiGen(opts.GnmiGenConfig, opts.GnmiGenConfigData); err != nil {
 		return s, fmt.Errorf("deploying gnmi-gen: %w", err)
@@ -196,7 +210,10 @@ func (s *Suite) deployGnmiGen(configPath string, data []byte) error {
 		return fmt.Errorf("applying config: %w", err)
 	}
 
-	vars := map[string]any{"ConfigHash": hex.EncodeToString(sum[:8])}
+	vars := map[string]any{
+		"ConfigHash": hex.EncodeToString(sum[:8]),
+		"TLSSecret":  s.GnmiGenTLSSecret,
+	}
 	if _, err := s.K8s.applyYAML(gnmiGenManifests, vars); err != nil {
 		return err
 	}

--- a/test/integration/harness/usage.go
+++ b/test/integration/harness/usage.go
@@ -5,7 +5,9 @@ package harness
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -19,17 +21,73 @@ type PodUsage struct {
 	MemoryBytes uint64  // working set
 }
 
+// UsageWindow aggregates instantaneous kubelet samples for one pod.
+type UsageWindow struct {
+	Name    string
+	Samples int
+	CPUMin  float64
+	CPUMax  float64
+	CPULast float64
+	MemMin  uint64
+	MemMax  uint64
+	MemLast uint64
+}
+
+// UsageSampler periodically samples selected pods via kubelet stats.
+// Sampling runs off the test goroutine; failures are recorded and checked on Stop.
+type UsageSampler struct {
+	k        *K8s
+	interval time.Duration
+	stop     chan struct{}
+	wg       sync.WaitGroup
+
+	mu       sync.Mutex
+	windows  map[string]*UsageWindow
+	lastErr  error
+	errCount int
+}
+
 // PodUsageOf fetches usage for a single pod via the node kubelet stats proxy.
 // kind exposes this without metrics-server.
 func (k *K8s) PodUsageOf(t *testing.T, pod corev1.Pod) PodUsage {
 	t.Helper()
-	if pod.Spec.NodeName == "" {
-		t.Fatalf("pod %s has no nodeName", pod.Name)
+	usages := k.PodUsagesOf(t, []corev1.Pod{pod})
+	u, ok := usages[pod.Name]
+	if !ok {
+		t.Fatalf("pod %s/%s not present in node stats summary", pod.Namespace, pod.Name)
 	}
-	summary, err := k.nodeStatsSummary(pod.Spec.NodeName)
-	if err != nil {
-		t.Fatalf("node stats for %s: %v", pod.Spec.NodeName, err)
+	return u
+}
+
+// PodUsagesOf fetches usage for many pods, caching one node stats summary per
+// distinct nodeName so large collector fleets do not re-fetch the same payload.
+func (k *K8s) PodUsagesOf(t *testing.T, pods []corev1.Pod) map[string]PodUsage {
+	t.Helper()
+	out := make(map[string]PodUsage, len(pods))
+	summaries := map[string]*nodeStatsSummary{}
+	for _, pod := range pods {
+		if pod.Spec.NodeName == "" {
+			t.Fatalf("pod %s has no nodeName", pod.Name)
+		}
+		summary, ok := summaries[pod.Spec.NodeName]
+		if !ok {
+			var err error
+			summary, err = k.nodeStatsSummary(pod.Spec.NodeName)
+			if err != nil {
+				t.Fatalf("node stats for %s: %v", pod.Spec.NodeName, err)
+			}
+			summaries[pod.Spec.NodeName] = summary
+		}
+		u, found := usageFromSummary(summary, pod)
+		if !found {
+			t.Fatalf("pod %s/%s not present in node stats summary", pod.Namespace, pod.Name)
+		}
+		out[pod.Name] = u
 	}
+	return out
+}
+
+func usageFromSummary(summary *nodeStatsSummary, pod corev1.Pod) (PodUsage, bool) {
 	for _, p := range summary.Pods {
 		if p.PodRef.Namespace != pod.Namespace || p.PodRef.Name != pod.Name {
 			continue
@@ -44,10 +102,9 @@ func (k *K8s) PodUsageOf(t *testing.T, pod corev1.Pod) PodUsage {
 			Name:        pod.Name,
 			CPUCores:    float64(cpu) / 1e9,
 			MemoryBytes: mem,
-		}
+		}, true
 	}
-	t.Fatalf("pod %s/%s not present in node stats summary", pod.Namespace, pod.Name)
-	return PodUsage{}
+	return PodUsage{}, false
 }
 
 // LogPodUsage writes a one-line usage summary for diagnostics / trend lines.
@@ -56,13 +113,30 @@ func LogPodUsage(t *testing.T, u PodUsage) {
 	t.Logf("usage %s: cpu=%.3f cores mem=%.1f MiB", u.Name, u.CPUCores, float64(u.MemoryBytes)/(1024*1024))
 }
 
+// LogUsageWindow writes min/max/last for a sampled pod.
+func LogUsageWindow(t *testing.T, w UsageWindow) {
+	t.Helper()
+	if w.Samples == 0 {
+		t.Logf("usage-window %s: no samples", w.Name)
+		return
+	}
+	t.Logf("usage-window %s: samples=%d cpu[min=%.3f max=%.3f last=%.3f] cores mem[min=%.1f max=%.1f last=%.1f] MiB",
+		w.Name, w.Samples,
+		w.CPUMin, w.CPUMax, w.CPULast,
+		float64(w.MemMin)/(1024*1024), float64(w.MemMax)/(1024*1024), float64(w.MemLast)/(1024*1024))
+}
+
 // AssertPodUsageWithinLimits fails if usage exceeds the pod's container limits
 // (when set). CPU without a limit is checked against a soft ceiling of 4 cores
 // so a runaway process still fails the suite.
 func AssertPodUsageWithinLimits(t *testing.T, pod corev1.Pod, u PodUsage) {
 	t.Helper()
-	LogPodUsage(t, u)
+	AssertPodUsageWithinLimitsQuiet(t, pod, u)
+}
 
+// AssertPodUsageWithinLimitsQuiet is AssertPodUsageWithinLimits without logging.
+func AssertPodUsageWithinLimitsQuiet(t *testing.T, pod corev1.Pod, u PodUsage) {
+	t.Helper()
 	var memLimit, cpuLimit int64
 	for _, c := range pod.Spec.Containers {
 		if q := c.Resources.Limits.Memory(); !q.IsZero() {
@@ -84,6 +158,165 @@ func AssertPodUsageWithinLimits(t *testing.T, pod corev1.Pod, u PodUsage) {
 	} else if u.CPUCores > 4 {
 		t.Fatalf("%s cpu %.3f cores exceeds soft ceiling of 4 (no limit set)", u.Name, u.CPUCores)
 	}
+}
+
+// AssertUsageWindowWithinLimits checks peak CPU/memory from a sample window.
+func AssertUsageWindowWithinLimits(t *testing.T, pod corev1.Pod, w UsageWindow) {
+	t.Helper()
+	if w.Samples == 0 {
+		t.Fatalf("%s: usage window has no samples", pod.Name)
+	}
+	AssertPodUsageWithinLimitsQuiet(t, pod, PodUsage{
+		Name:        w.Name,
+		CPUCores:    w.CPUMax,
+		MemoryBytes: w.MemMax,
+	})
+}
+
+// StartOperatorUsageSampler samples controller-manager pods every interval
+// until Stop. Use around converge/churn/chaos to capture peak compute, not
+// only the idle post-Ready reading.
+func (k *K8s) StartOperatorUsageSampler(interval time.Duration) *UsageSampler {
+	if interval <= 0 {
+		interval = 2 * time.Second
+	}
+	s := &UsageSampler{
+		k:        k,
+		interval: interval,
+		stop:     make(chan struct{}),
+		windows:  map[string]*UsageWindow{},
+	}
+	s.sampleOnce()
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-s.stop:
+				return
+			case <-ticker.C:
+				s.sampleOnce()
+			}
+		}
+	}()
+	return s
+}
+
+func (s *UsageSampler) sampleOnce() {
+	pods, err := s.k.listOperatorPods()
+	if err != nil {
+		s.recordErr(err)
+		return
+	}
+	if len(pods) == 0 {
+		s.recordErr(fmt.Errorf("no controller-manager pods"))
+		return
+	}
+	summaries := map[string]*nodeStatsSummary{}
+	for _, pod := range pods {
+		if pod.Spec.NodeName == "" {
+			s.recordErr(fmt.Errorf("pod %s has no nodeName", pod.Name))
+			continue
+		}
+		summary, ok := summaries[pod.Spec.NodeName]
+		if !ok {
+			summary, err = s.k.nodeStatsSummary(pod.Spec.NodeName)
+			if err != nil {
+				s.recordErr(fmt.Errorf("node stats for %s: %w", pod.Spec.NodeName, err))
+				continue
+			}
+			summaries[pod.Spec.NodeName] = summary
+		}
+		u, found := usageFromSummary(summary, pod)
+		if !found {
+			s.recordErr(fmt.Errorf("pod %s/%s missing from node stats", pod.Namespace, pod.Name))
+			continue
+		}
+		s.record(u)
+	}
+}
+
+func (s *UsageSampler) recordErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastErr = err
+	s.errCount++
+}
+
+func (s *UsageSampler) record(u PodUsage) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	w := s.windows[u.Name]
+	if w == nil {
+		w = &UsageWindow{
+			Name:   u.Name,
+			CPUMin: u.CPUCores,
+			MemMin: u.MemoryBytes,
+		}
+		s.windows[u.Name] = w
+	}
+	if w.Samples == 0 || u.CPUCores < w.CPUMin {
+		w.CPUMin = u.CPUCores
+	}
+	if u.CPUCores > w.CPUMax {
+		w.CPUMax = u.CPUCores
+	}
+	if w.Samples == 0 || u.MemoryBytes < w.MemMin {
+		w.MemMin = u.MemoryBytes
+	}
+	if u.MemoryBytes > w.MemMax {
+		w.MemMax = u.MemoryBytes
+	}
+	w.CPULast = u.CPUCores
+	w.MemLast = u.MemoryBytes
+	w.Samples++
+}
+
+// Stop ends sampling and returns one window per observed pod name.
+func (s *UsageSampler) Stop() []UsageWindow {
+	close(s.stop)
+	s.wg.Wait()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]UsageWindow, 0, len(s.windows))
+	for _, w := range s.windows {
+		out = append(out, *w)
+	}
+	return out
+}
+
+// StopAndLog stops sampling and logs each window. Fails the test if no samples
+// were collected (kubelet stats unavailable).
+func (s *UsageSampler) StopAndLog(t *testing.T, label string) []UsageWindow {
+	t.Helper()
+	windows := s.Stop()
+	s.mu.Lock()
+	lastErr, errCount := s.lastErr, s.errCount
+	s.mu.Unlock()
+	if label != "" {
+		t.Logf("operator usage during %s:", label)
+	}
+	if len(windows) == 0 {
+		t.Fatalf("operator usage sampler collected no samples (errors=%d last=%v)", errCount, lastErr)
+	}
+	if errCount > 0 {
+		t.Logf("operator usage sampler: %d sample errors (last: %v)", errCount, lastErr)
+	}
+	for _, w := range windows {
+		LogUsageWindow(t, w)
+	}
+	return windows
+}
+
+// SampleOperatorUsageFor samples operator pods for dur, logging the window.
+// Useful for a short post-converge stability soak.
+func (k *K8s) SampleOperatorUsageFor(t *testing.T, dur, interval time.Duration, label string) []UsageWindow {
+	t.Helper()
+	s := k.StartOperatorUsageSampler(interval)
+	time.Sleep(dur)
+	return s.StopAndLog(t, label)
 }
 
 type nodeStatsSummary struct {

--- a/test/integration/suite/003-targets/fixtures/baseline.yaml
+++ b/test/integration/suite/003-targets/fixtures/baseline.yaml
@@ -1,0 +1,69 @@
+# Shared props for 003-targets. Target CRs are created per test.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sim-credentials
+stringData:
+  username: gnmic
+  password: gnmic
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: TargetProfile
+metadata:
+  name: default
+spec:
+  credentialsRef: sim-credentials
+  encoding: JSON_IETF
+  timeout: 10s
+  tls: {}
+  retryTimer: 2s
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: c1
+spec:
+  image: {{ .GnmicImage }}
+  replicas: 1
+  api:
+    restPort: 7890
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: if-counters
+  labels:
+    suite: "003"
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 1s
+  encoding: JSON_IETF
+  paths:
+    - /interface/statistics/in-octets
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: prom
+  labels:
+    suite: "003"
+spec:
+  type: prometheus
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: collect
+spec:
+  clusterRef: c1
+  enabled: true
+  targetSelectors:
+    - matchLabels:
+        vendor: gnmi-gen
+  subscriptionSelectors:
+    - matchLabels:
+        suite: "003"
+  outputs:
+    outputSelectors:
+      - matchLabels:
+          suite: "003"

--- a/test/integration/suite/003-targets/fixtures/cluster.yaml
+++ b/test/integration/suite/003-targets/fixtures/cluster.yaml
@@ -1,0 +1,9 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: {{ .Name }}
+spec:
+  image: {{ .GnmicImage }}
+  replicas: {{ .Replicas }}
+  api:
+    restPort: 7890

--- a/test/integration/suite/003-targets/fixtures/pipeline.yaml
+++ b/test/integration/suite/003-targets/fixtures/pipeline.yaml
@@ -1,0 +1,17 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: {{ .Name }}
+spec:
+  clusterRef: {{ .Cluster }}
+  enabled: true
+  targetSelectors:
+    - matchLabels:
+        vendor: gnmi-gen
+  subscriptionSelectors:
+    - matchLabels:
+        suite: "003"
+  outputs:
+    outputSelectors:
+      - matchLabels:
+          suite: "003"

--- a/test/integration/suite/003-targets/fixtures/target.yaml
+++ b/test/integration/suite/003-targets/fixtures/target.yaml
@@ -1,0 +1,12 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: {{ .Name }}
+  labels:
+    vendor: gnmi-gen
+{{- if ne .Role "" }}
+    role: {{ .Role }}
+{{- end }}
+spec:
+  address: {{ .GnmiGenHost }}:{{ .Port }}
+  profile: {{ .Profile }}

--- a/test/integration/suite/003-targets/gnmi-gen.yaml
+++ b/test/integration/suite/003-targets/gnmi-gen.yaml
@@ -1,0 +1,79 @@
+global:
+  seed: 42
+  shutdown_timeout: 5s
+
+api:
+  listen: 0.0.0.0:8080
+
+data_profiles:
+  interface_counter:
+    type: uint64
+    update_frequency: 1s
+    random:
+      distribution: counter
+      min: 100000
+      max: 900000
+      step_min: 100
+      step_max: 10000
+
+  system_name:
+    type: string
+    update_frequency: 10s
+    random:
+      value: leaf-{{.index}}
+
+  system_name_spine:
+    type: string
+    update_frequency: 10s
+    random:
+      value: spine-1
+
+  system_name_leaf3:
+    type: string
+    update_frequency: 10s
+    random:
+      value: leaf-3
+
+servers:
+  - name: leaf{{.index}}
+    expand:
+      index:
+        start: 1
+        end: 2
+      listen:
+        host: 0.0.0.0
+        port_start: 57400
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name
+
+  - name: spine1
+    listen: 0.0.0.0:57402
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name_spine
+
+  # Spare simulator for address-move tests; no Target CR until a test points at it.
+  - name: leaf3
+    listen: 0.0.0.0:57403
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name_leaf3

--- a/test/integration/suite/003-targets/targets_test.go
+++ b/test/integration/suite/003-targets/targets_test.go
@@ -1,0 +1,490 @@
+//go:build integration
+
+// Package targets covers Target / TargetProfile lifecycle, credential and
+// address failures, reboot-driven status, and multi-cluster status reporting.
+package targets
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gnmicv1alpha1 "github.com/gnmic/operator/api/v1alpha1"
+	"github.com/gnmic/operator/test/integration/harness"
+)
+
+var s *harness.Suite
+
+const (
+	cluster  = "c1"
+	pipeline = "collect"
+	output   = "prom"
+	pathIF   = "/interface/statistics/in-octets"
+
+	leaf1  = "leaf1"
+	leaf2  = "leaf2"
+	spine1 = "spine1"
+	leaf3  = "leaf3" // simulator only until a test points a CR at :57403
+
+	portLeaf1 = 57400
+	portLeaf2 = 57401
+	portSpine = 57402
+	portLeaf3 = 57403
+	portGhost = 57999
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(harness.RunSuite(m, harness.Options{
+		Name:           "003-targets",
+		RequireTargets: []string{leaf1, leaf2, spine1, leaf3},
+		Baseline:       []string{"fixtures/baseline.yaml"},
+	}, &s))
+}
+
+func waitClusterReady(t *testing.T) {
+	t.Helper()
+	harness.WaitClusterReady(t, s.K8s, cluster)
+	s.K8s.WaitReadyPods(t, cluster, 1, harness.Long)
+}
+
+// waitIdle deletes leftover Targets (and optional extra clusters/pipelines)
+// from prior tests, then waits until the wire is quiet.
+func waitIdle(t *testing.T) {
+	t.Helper()
+	var targets gnmicv1alpha1.TargetList
+	if err := s.K8s.Client.List(s.Ctx, &targets, client.InNamespace(s.Namespace)); err == nil {
+		for i := range targets.Items {
+			_ = s.K8s.Client.Delete(s.Ctx, &targets.Items[i])
+		}
+	}
+	var pipelines gnmicv1alpha1.PipelineList
+	if err := s.K8s.Client.List(s.Ctx, &pipelines, client.InNamespace(s.Namespace)); err == nil {
+		for i := range pipelines.Items {
+			if pipelines.Items[i].Name == pipeline {
+				continue
+			}
+			_ = s.K8s.Client.Delete(s.Ctx, &pipelines.Items[i])
+		}
+	}
+	var clusters gnmicv1alpha1.ClusterList
+	if err := s.K8s.Client.List(s.Ctx, &clusters, client.InNamespace(s.Namespace)); err == nil {
+		for i := range clusters.Items {
+			if clusters.Items[i].Name == cluster {
+				continue
+			}
+			_ = s.K8s.Client.Delete(s.Ctx, &clusters.Items[i])
+		}
+	}
+
+	harness.Wait(t, harness.Medium, "extra clusters gone", func() (bool, string) {
+		var left gnmicv1alpha1.ClusterList
+		if err := s.K8s.Client.List(s.Ctx, &left, client.InNamespace(s.Namespace)); err != nil {
+			return false, err.Error()
+		}
+		n := 0
+		for _, c := range left.Items {
+			if c.Name != cluster {
+				n++
+			}
+		}
+		return n == 0, fmt.Sprintf("%d extra cluster(s)", n)
+	})
+	harness.Wait(t, harness.Medium, "all Target CRs gone", func() (bool, string) {
+		var left gnmicv1alpha1.TargetList
+		if err := s.K8s.Client.List(s.Ctx, &left, client.InNamespace(s.Namespace)); err != nil {
+			return false, err.Error()
+		}
+		return len(left.Items) == 0, fmt.Sprintf("%d remain", len(left.Items))
+	})
+	harness.Wait(t, harness.Medium, "all simulated targets idle", func() (bool, string) {
+		for _, name := range []string{leaf1, leaf2, spine1, leaf3} {
+			if n := s.GnmiGen.StreamCount(name); n != 0 {
+				return false, fmt.Sprintf("%s has %d streams", name, n)
+			}
+		}
+		return true, ""
+	})
+	waitClusterReady(t)
+}
+
+func applyTarget(t *testing.T, name string, port int, profile, role string) {
+	t.Helper()
+	if profile == "" {
+		profile = "default"
+	}
+	s.K8s.ApplyFile(t, "fixtures/target.yaml", map[string]any{
+		"Name":    name,
+		"Port":    port,
+		"Profile": profile,
+		"Role":    role,
+	})
+}
+
+func establishedSnapshot(names ...string) map[string]time.Time {
+	out := make(map[string]time.Time, len(names))
+	for _, n := range names {
+		out[n] = s.GnmiGen.EstablishedAt(n)
+	}
+	return out
+}
+
+func assertEstablishedStable(t *testing.T, before map[string]time.Time, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		was := before[name]
+		now := s.GnmiGen.EstablishedAt(name)
+		if was.IsZero() || now.IsZero() {
+			t.Errorf("%s missing established_at before=%v after=%v", name, was, now)
+			continue
+		}
+		if now.Sub(was).Abs() > time.Second {
+			t.Errorf("%s re-established: %s -> %s", name, was, now)
+		}
+	}
+}
+
+func TestTarget001_CreatingStartsOneStream(t *testing.T) {
+	waitIdle(t)
+	applyTarget(t, leaf1, portLeaf1, "default", "leaf")
+
+	s.GnmiGen.WaitStreams(t, leaf1, 1)
+	s.GnmiGen.WaitPathPresent(t, leaf1, pathIF)
+	s.GnmiGen.WaitStreams(t, leaf2, 0)
+	s.GnmiGen.WaitStreams(t, spine1, 0)
+	s.GnmiGen.WaitStreams(t, leaf3, 0)
+
+	harness.WaitTargetState(t, s.K8s, leaf1, "READY")
+	tgt := s.K8s.Target(t, leaf1)
+	if tgt.Status.Clusters != 1 {
+		t.Errorf("clusters=%d want 1", tgt.Status.Clusters)
+	}
+	if got := tgt.Status.ClusterStates[cluster].Pod; got != harness.PodName(cluster, 0) {
+		t.Errorf("pod=%q want %s", got, harness.PodName(cluster, 0))
+	}
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 10*time.Second, 1, leaf1)
+}
+
+func TestTarget002_ProfileSuppliesConnectionParams(t *testing.T) {
+	waitIdle(t)
+	applyTarget(t, leaf1, portLeaf1, "default", "leaf")
+	s.GnmiGen.WaitStreams(t, leaf1, 1)
+	harness.WaitTargetState(t, s.K8s, leaf1, "READY")
+
+	// gnmi-gen does not report Subscribe encoding, and an encoding-only target
+	// update does not tear down the stream, so we cannot assert a new
+	// established_at. Prove the profile edit is live by staying collected
+	// without a collector restart.
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	prof := s.K8s.TargetProfile(t, "default")
+	s.K8s.Patch(t, prof, `{"spec":{"encoding":"PROTO"}}`)
+	t.Cleanup(func() {
+		s.K8s.Patch(t, s.K8s.TargetProfile(t, "default"), `{"spec":{"encoding":"JSON_IETF"}}`)
+	})
+
+	harness.WaitTargetState(t, s.K8s, leaf1, "READY")
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 10*time.Second, 1, leaf1)
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}
+
+func TestTarget003_WrongCredentialsFailAndRecover(t *testing.T) {
+	waitIdle(t)
+	applyTarget(t, leaf1, portLeaf1, "default", "leaf")
+	s.GnmiGen.WaitStreams(t, leaf1, 1)
+
+	badSecret := &corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{Name: "bad-credentials", Namespace: s.Namespace},
+		Type:       corev1.SecretTypeOpaque,
+		StringData: map[string]string{"username": "gnmic", "password": "wrong"},
+	}
+	if err := s.K8s.ApplyNoCleanup(badSecret); err != nil {
+		t.Fatalf("applying bad secret: %v", err)
+	}
+	badProfile := `
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: TargetProfile
+metadata:
+  name: bad-auth
+spec:
+  credentialsRef: bad-credentials
+  encoding: JSON_IETF
+  timeout: 5s
+  tls: {}
+  retryTimer: 2s
+`
+	if _, err := s.K8s.ApplyYAMLNoCleanup(badProfile, nil); err != nil {
+		t.Fatalf("applying bad profile: %v", err)
+	}
+	applyTarget(t, leaf2, portLeaf2, "bad-auth", "leaf")
+
+	harness.Wait(t, harness.Medium, "leaf2 failed auth", func() (bool, string) {
+		tgt, err := s.K8s.TargetQuiet(leaf2)
+		if err != nil {
+			return false, err.Error()
+		}
+		if tgt.Status.State == "READY" {
+			return false, "still READY"
+		}
+		cs := tgt.Status.ClusterStates[cluster]
+		if cs.State != "failed" {
+			return false, fmt.Sprintf("state=%q connection=%q", cs.State, cs.ConnectionState)
+		}
+		if cs.FailedReason == "" {
+			return false, "failedReason empty"
+		}
+		return true, ""
+	})
+	s.GnmiGen.WaitStreams(t, leaf2, 0)
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 5*time.Second, 1, leaf1)
+
+	// Replace the Secret via YAML apply (avoids managedFields on a reused object),
+	// then bump the profile so the Cluster reconciler is guaranteed to rebuild
+	// the plan with the new password even if the Secret watch is slow.
+	fixedSecret := `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bad-credentials
+type: Opaque
+stringData:
+  username: gnmic
+  password: gnmic
+`
+	if _, err := s.K8s.ApplyYAMLNoCleanup(fixedSecret, nil); err != nil {
+		t.Fatalf("fixing credentials: %v", err)
+	}
+	s.K8s.Patch(t, s.K8s.TargetProfile(t, "bad-auth"), `{"spec":{"timeout":"6s"}}`)
+
+	harness.WaitTargetState(t, s.K8s, leaf2, "READY")
+	s.GnmiGen.WaitStreams(t, leaf2, 1)
+}
+
+func TestTarget004_AddressChangeMovesStream(t *testing.T) {
+	waitIdle(t)
+	applyTarget(t, leaf1, portLeaf1, "default", "leaf")
+	s.GnmiGen.WaitStreams(t, leaf1, 1)
+	harness.WaitTargetState(t, s.K8s, leaf1, "READY")
+	s.K8s.WaitClusterPrometheusSources(t, cluster, pipeline, output, []string{leaf1}, harness.Medium)
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	host := harness.GnmiGenHost(s.Namespace)
+	s.K8s.Patch(t, s.K8s.Target(t, leaf1),
+		fmt.Sprintf(`{"spec":{"address":%q}}`, fmt.Sprintf("%s:%d", host, portLeaf3)))
+
+	s.GnmiGen.WaitStreams(t, leaf3, 1)
+	s.GnmiGen.WaitStreams(t, leaf1, 0)
+	harness.WaitTargetState(t, s.K8s, leaf1, "READY")
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+	// Source label follows the Target CR name, not the simulator listen name.
+	s.K8s.WaitClusterPrometheusSources(t, cluster, pipeline, output, []string{leaf1}, harness.Medium)
+}
+
+func TestTarget005_UnreachableAddressDegradesCleanly(t *testing.T) {
+	waitIdle(t)
+	applyTarget(t, leaf1, portLeaf1, "default", "leaf")
+	s.GnmiGen.WaitStreams(t, leaf1, 1)
+	harness.WaitTargetState(t, s.K8s, leaf1, "READY")
+
+	applyTarget(t, "ghost", portGhost, "default", "")
+	harness.Wait(t, harness.Medium, "ghost not READY", func() (bool, string) {
+		tgt, err := s.K8s.TargetQuiet("ghost")
+		if err != nil {
+			return false, err.Error()
+		}
+		if tgt.Status.State == "READY" {
+			return false, "ghost reached READY"
+		}
+		cs := tgt.Status.ClusterStates[cluster]
+		if cs.State == "" && cs.ConnectionState == "" {
+			return false, "no cluster state yet"
+		}
+		return cs.State != "running" || cs.ConnectionState != "READY",
+			fmt.Sprintf("state=%q connection=%q", cs.State, cs.ConnectionState)
+	})
+
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		TargetsCount: harness.I32(2),
+	})
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	// Adding ghost re-applies the pod plan and can briefly flap leaf1's CR
+	// connectionState; the wire invariant is what isolation requires.
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 20*time.Second, 1, leaf1)
+	harness.WaitTargetState(t, s.K8s, leaf1, "READY")
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+	harness.AssertNoPanics(t, s.K8s.Logs(t, harness.PodName(cluster, 0), 2*time.Minute))
+}
+
+func TestTarget006_DeviceRebootDegradesAndRecovers(t *testing.T) {
+	waitIdle(t)
+	applyTarget(t, leaf1, portLeaf1, "default", "leaf")
+	s.GnmiGen.WaitStreams(t, leaf1, 1)
+	harness.WaitTargetState(t, s.K8s, leaf1, "READY")
+	beforeEstab := s.GnmiGen.EstablishedAt(leaf1)
+	simBefore, err := s.GnmiGen.Target(leaf1)
+	if err != nil {
+		t.Fatalf("gnmi-gen target: %v", err)
+	}
+
+	if err := s.GnmiGen.Reboot(20*time.Second, leaf1); err != nil {
+		t.Fatalf("reboot: %v", err)
+	}
+
+	harness.Wait(t, harness.Medium, "leaf1 leaves READY during reboot", func() (bool, string) {
+		tgt, err := s.K8s.TargetQuiet(leaf1)
+		if err != nil {
+			return false, err.Error()
+		}
+		return tgt.Status.State != "READY", "state=" + tgt.Status.State
+	})
+	harness.Wait(t, harness.Medium, "sim rebooting with zero streams", func() (bool, string) {
+		sim, err := s.GnmiGen.Target(leaf1)
+		if err != nil {
+			return false, err.Error()
+		}
+		n := s.GnmiGen.StreamCount(leaf1)
+		return (sim.Status == "rebooting" || n == 0), fmt.Sprintf("status=%s streams=%d", sim.Status, n)
+	})
+
+	s.GnmiGen.WaitTargetsUp(t, leaf1)
+	s.GnmiGen.WaitStreams(t, leaf1, 1)
+	harness.WaitTargetState(t, s.K8s, leaf1, "READY")
+
+	simAfter, err := s.GnmiGen.Target(leaf1)
+	if err != nil {
+		t.Fatalf("gnmi-gen target after: %v", err)
+	}
+	if simAfter.RebootCount <= simBefore.RebootCount {
+		t.Errorf("reboot_count did not increment: %d -> %d", simBefore.RebootCount, simAfter.RebootCount)
+	}
+	afterEstab := s.GnmiGen.EstablishedAt(leaf1)
+	if afterEstab.IsZero() || afterEstab.Sub(beforeEstab).Abs() <= time.Second {
+		t.Errorf("expected fresh established_at; before=%v after=%v", beforeEstab, afterEstab)
+	}
+	if n := s.GnmiGen.StreamCount(leaf1); n != 1 {
+		t.Fatalf("want exactly 1 stream after reboot, got %d", n)
+	}
+	s.GnmiGen.WaitNotificationsAdvance(t, leaf1)
+}
+
+func TestTarget007_RebootOneDoesNotDisturbOthers(t *testing.T) {
+	waitIdle(t)
+	applyTarget(t, leaf1, portLeaf1, "default", "leaf")
+	applyTarget(t, leaf2, portLeaf2, "default", "leaf")
+	applyTarget(t, spine1, portSpine, "default", "spine")
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2, spine1)
+
+	estab := establishedSnapshot(leaf1, leaf2)
+	notifBefore := map[string]int{
+		leaf1: s.GnmiGen.Notifications(leaf1),
+		leaf2: s.GnmiGen.Notifications(leaf2),
+	}
+
+	if err := s.GnmiGen.Reboot(20*time.Second, spine1); err != nil {
+		t.Fatalf("reboot: %v", err)
+	}
+
+	deadline := time.Now().Add(25 * time.Second)
+	for time.Now().Before(deadline) {
+		if n := s.GnmiGen.StreamCount(leaf1); n != 1 {
+			t.Fatalf("leaf1 streams=%d during spine reboot", n)
+		}
+		if n := s.GnmiGen.StreamCount(leaf2); n != 1 {
+			t.Fatalf("leaf2 streams=%d during spine reboot", n)
+		}
+		time.Sleep(time.Second)
+	}
+	assertEstablishedStable(t, estab, leaf1, leaf2)
+	if s.GnmiGen.Notifications(leaf1) <= notifBefore[leaf1] {
+		t.Error("leaf1 notifications did not advance during spine reboot")
+	}
+	if s.GnmiGen.Notifications(leaf2) <= notifBefore[leaf2] {
+		t.Error("leaf2 notifications did not advance during spine reboot")
+	}
+
+	s.GnmiGen.WaitTargetsUp(t, spine1)
+	s.GnmiGen.WaitStreams(t, spine1, 1)
+	harness.WaitTargetState(t, s.K8s, spine1, "READY")
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2, spine1)
+}
+
+func TestTarget008_DeletingTargetStopsCollection(t *testing.T) {
+	waitIdle(t)
+	applyTarget(t, leaf1, portLeaf1, "default", "leaf")
+	applyTarget(t, leaf2, portLeaf2, "default", "leaf")
+	s.GnmiGen.AssertCollectedOnce(t, 1, leaf1, leaf2)
+	s.K8s.WaitClusterPrometheusSources(t, cluster, pipeline, output, []string{leaf1, leaf2}, harness.Medium)
+	estab := establishedSnapshot(leaf2)
+
+	s.K8s.Delete(t, s.K8s.Target(t, leaf1))
+	s.GnmiGen.WaitStreams(t, leaf1, 0)
+	s.K8s.WaitAbsent(t, leaf1, &gnmicv1alpha1.Target{})
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		TargetsCount: harness.I32(1),
+	})
+	s.GnmiGen.WaitStreams(t, leaf2, 1)
+	assertEstablishedStable(t, estab, leaf2)
+
+	s.K8s.WaitClusterPrometheusSources(t, cluster, pipeline, output, []string{leaf2}, harness.Medium)
+	harness.Wait(t, harness.Medium, "prometheus dropped leaf1", func() (bool, string) {
+		body := s.K8s.ScrapeClusterPrometheus(t, cluster, pipeline, output)
+		sources := harness.LabelValues(body, "source")
+		for _, src := range sources {
+			if src == leaf1 || strings.HasSuffix(src, "/"+leaf1) {
+				return false, fmt.Sprintf("leaf1 still in sources=%v", sources)
+			}
+		}
+		return true, fmt.Sprintf("sources=%v", sources)
+	})
+}
+
+func TestTarget009_TwoClustersReportBoth(t *testing.T) {
+	waitIdle(t)
+	applyTarget(t, leaf1, portLeaf1, "default", "leaf")
+	s.GnmiGen.WaitStreams(t, leaf1, 1)
+	harness.WaitTargetState(t, s.K8s, leaf1, "READY")
+
+	const c2 = "c2"
+	s.K8s.ApplyFile(t, "fixtures/cluster.yaml", map[string]any{
+		"Name":     c2,
+		"Replicas": 1,
+	})
+	s.K8s.ApplyFile(t, "fixtures/pipeline.yaml", map[string]any{
+		"Name":    "collect-c2",
+		"Cluster": c2,
+	})
+	s.K8s.WaitReadyPods(t, c2, 1, harness.Long)
+
+	harness.Wait(t, harness.Medium, "leaf1 collected by two clusters", func() (bool, string) {
+		tgt, err := s.K8s.TargetQuiet(leaf1)
+		if err != nil {
+			return false, err.Error()
+		}
+		if tgt.Status.Clusters != 2 {
+			return false, fmt.Sprintf("clusters=%d", tgt.Status.Clusters)
+		}
+		if tgt.Status.ClusterStates[cluster].Pod == "" || tgt.Status.ClusterStates[c2].Pod == "" {
+			return false, fmt.Sprintf("states=%v", tgt.Status.ClusterStates)
+		}
+		if n := s.GnmiGen.StreamCount(leaf1); n != 2 {
+			return false, fmt.Sprintf("streams=%d", n)
+		}
+		return true, ""
+	})
+
+	s.K8s.Delete(t, s.K8s.Cluster(t, c2))
+	s.K8s.WaitAbsent(t, c2, &gnmicv1alpha1.Cluster{})
+	s.GnmiGen.WaitStreams(t, leaf1, 1)
+	harness.Wait(t, harness.Medium, "clusters back to 1", func() (bool, string) {
+		tgt, err := s.K8s.TargetQuiet(leaf1)
+		if err != nil {
+			return false, err.Error()
+		}
+		return tgt.Status.Clusters == 1, fmt.Sprintf("clusters=%d", tgt.Status.Clusters)
+	})
+}

--- a/test/integration/suite/004-subscriptions/fixtures/baseline.yaml
+++ b/test/integration/suite/004-subscriptions/fixtures/baseline.yaml
@@ -1,0 +1,86 @@
+# Shared props for 004-subscriptions. Subscription CRs are created per test.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sim-credentials
+stringData:
+  username: gnmic
+  password: gnmic
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: TargetProfile
+metadata:
+  name: default
+spec:
+  credentialsRef: sim-credentials
+  encoding: JSON_IETF
+  timeout: 10s
+  tls: {}
+  retryTimer: 2s
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: c1
+spec:
+  image: {{ .GnmicImage }}
+  replicas: 1
+  api:
+    restPort: 7890
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: leaf1
+  labels:
+    vendor: gnmi-gen
+spec:
+  address: {{ .GnmiGenHost }}:57400
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: leaf2
+  labels:
+    vendor: gnmi-gen
+spec:
+  address: {{ .GnmiGenHost }}:57401
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: spine1
+  labels:
+    vendor: gnmi-gen
+spec:
+  address: {{ .GnmiGenHost }}:57402
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: prom
+  labels:
+    suite: "004"
+spec:
+  type: prometheus
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: collect
+spec:
+  clusterRef: c1
+  enabled: true
+  targetSelectors:
+    - matchLabels:
+        vendor: gnmi-gen
+  subscriptionSelectors:
+    - matchLabels:
+        suite: "004"
+  outputs:
+    outputSelectors:
+      - matchLabels:
+          suite: "004"

--- a/test/integration/suite/004-subscriptions/fixtures/subscription.yaml
+++ b/test/integration/suite/004-subscriptions/fixtures/subscription.yaml
@@ -1,0 +1,31 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .Name }}
+  labels:
+    suite: "004"
+spec:
+  mode: {{ .Mode }}
+{{- if ne .SampleInterval "" }}
+  sampleInterval: {{ .SampleInterval }}
+{{- end }}
+{{- if ne .HeartbeatInterval "" }}
+  heartbeatInterval: {{ .HeartbeatInterval }}
+{{- end }}
+{{- if .UpdatesOnly }}
+  updatesOnly: true
+{{- end }}
+{{- if .SuppressRedundant }}
+  suppressRedundant: true
+{{- end }}
+{{- if ne .Prefix "" }}
+  prefix: {{ .Prefix }}
+{{- end }}
+{{- if ne .Target "" }}
+  target: {{ .Target }}
+{{- end }}
+  encoding: JSON_IETF
+  paths:
+{{- range .Paths }}
+    - {{ . }}
+{{- end }}

--- a/test/integration/suite/004-subscriptions/gnmi-gen.yaml
+++ b/test/integration/suite/004-subscriptions/gnmi-gen.yaml
@@ -1,0 +1,76 @@
+global:
+  seed: 42
+  shutdown_timeout: 5s
+
+api:
+  listen: 0.0.0.0:8080
+
+data_profiles:
+  interface_counter:
+    type: uint64
+    update_frequency: 1s
+    random:
+      distribution: counter
+      min: 100000
+      max: 900000
+      step_min: 100
+      step_max: 10000
+
+  cpu_utilization:
+    type: uint64
+    update_frequency: 500ms
+    random:
+      distribution: uniform
+      min: 5
+      max: 95
+
+  system_name:
+    type: string
+    update_frequency: 10s
+    random:
+      value: leaf-{{.index}}
+
+  system_name_spine:
+    type: string
+    update_frequency: 10s
+    random:
+      value: spine-1
+
+servers:
+  - name: leaf{{.index}}
+    expand:
+      index:
+        start: 1
+        end: 2
+      listen:
+        host: 0.0.0.0
+        port_start: 57400
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics
+        profile: interface_counter
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /platform/control/process
+        profile: cpu_utilization
+      - path: /system/name
+        profile: system_name
+
+  - name: spine1
+    listen: 0.0.0.0:57402
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics
+        profile: interface_counter
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /platform/control/process
+        profile: cpu_utilization
+      - path: /system/name
+        profile: system_name_spine

--- a/test/integration/suite/004-subscriptions/subscriptions_test.go
+++ b/test/integration/suite/004-subscriptions/subscriptions_test.go
@@ -1,0 +1,551 @@
+//go:build integration
+
+// Package subscriptions covers Subscription CR edits reaching the wire:
+// paths, sample interval, stream mode, updatesOnly, suppressRedundant,
+// prefix, deletion, and rapid successive patches — without collector restarts.
+package subscriptions
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gnmicv1alpha1 "github.com/gnmic/operator/api/v1alpha1"
+	"github.com/gnmic/operator/test/integration/harness"
+)
+
+var s *harness.Suite
+
+const (
+	cluster  = "c1"
+	pipeline = "collect"
+	output   = "prom"
+
+	leaf1  = "leaf1"
+	leaf2  = "leaf2"
+	spine1 = "spine1"
+
+	pathIF  = "/interface/statistics"
+	pathCPU = "/platform/control/process"
+	pathSys = "/system/name"
+)
+
+var allTargets = []string{leaf1, leaf2, spine1}
+
+func TestMain(m *testing.M) {
+	os.Exit(harness.RunSuite(m, harness.Options{
+		Name:           "004-subscriptions",
+		RequireTargets: allTargets,
+		Baseline:       []string{"fixtures/baseline.yaml"},
+	}, &s))
+}
+
+func waitClusterReady(t *testing.T) {
+	t.Helper()
+	harness.WaitClusterReady(t, s.K8s, cluster)
+	s.K8s.WaitReadyPods(t, cluster, 1, harness.Long)
+}
+
+func setPipelineEnabled(t *testing.T, enabled bool) {
+	t.Helper()
+	s.K8s.Patch(t, s.K8s.Pipeline(t, pipeline), fmt.Sprintf(`{"spec":{"enabled":%t}}`, enabled))
+}
+
+// waitIdle deletes suite Subscriptions left by a prior test, then waits until
+// every simulated target reports zero streams.
+//
+// gNMIc rejects an apply that still has targets but no subscriptions
+// ("if targets are provided, at least one subscription is required"), so
+// deleting the last Subscription alone cannot drain the collector — the
+// previous config sticks and streams stay open. Disable the pipeline so the
+// operator can apply an empty plan and tear the streams down.
+func waitIdle(t *testing.T) {
+	t.Helper()
+	var list gnmicv1alpha1.SubscriptionList
+	if err := s.K8s.Client.List(s.Ctx, &list, client.InNamespace(s.Namespace)); err == nil {
+		for i := range list.Items {
+			sub := &list.Items[i]
+			if sub.Labels["suite"] != "004" {
+				continue
+			}
+			_ = s.K8s.Client.Delete(s.Ctx, sub)
+		}
+	}
+	harness.Wait(t, harness.Medium, "suite-004 Subscriptions gone", func() (bool, string) {
+		var left gnmicv1alpha1.SubscriptionList
+		if err := s.K8s.Client.List(s.Ctx, &left, client.InNamespace(s.Namespace)); err != nil {
+			return false, err.Error()
+		}
+		n := 0
+		for _, sub := range left.Items {
+			if sub.Labels["suite"] == "004" {
+				n++
+			}
+		}
+		return n == 0, fmt.Sprintf("%d remain", n)
+	})
+	setPipelineEnabled(t, false)
+	harness.Wait(t, harness.Medium, "all simulated targets idle", func() (bool, string) {
+		for _, name := range allTargets {
+			if n := s.GnmiGen.StreamCount(name); n != 0 {
+				return false, fmt.Sprintf("%s has %d streams", name, n)
+			}
+		}
+		return true, ""
+	})
+	s.K8s.WaitReadyPods(t, cluster, 1, harness.Long)
+}
+
+func applySubscription(t *testing.T, name string, vars map[string]any) {
+	t.Helper()
+	setPipelineEnabled(t, true)
+	base := map[string]any{
+		"Name":              name,
+		"Mode":              "STREAM/SAMPLE",
+		"SampleInterval":    "1s",
+		"HeartbeatInterval": "",
+		"UpdatesOnly":       false,
+		"SuppressRedundant": false,
+		"Prefix":            "",
+		"Target":            "",
+		"Paths":             []string{pathIF},
+	}
+	for k, v := range vars {
+		base[k] = v
+	}
+	b, err := os.ReadFile("fixtures/subscription.yaml")
+	if err != nil {
+		t.Fatalf("reading subscription fixture: %v", err)
+	}
+	if _, err := s.K8s.ApplyYAMLNoCleanup(string(b), base); err != nil {
+		t.Fatalf("applying subscription %s: %v", name, err)
+	}
+	waitClusterReady(t)
+}
+
+func subscription(t *testing.T, name string) *gnmicv1alpha1.Subscription {
+	t.Helper()
+	o := &gnmicv1alpha1.Subscription{}
+	s.K8s.WaitExists(t, name, o)
+	return o
+}
+
+func patchSubscription(t *testing.T, name string, patch map[string]any) {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{"spec": patch})
+	if err != nil {
+		t.Fatalf("marshal patch: %v", err)
+	}
+	s.K8s.Patch(t, subscription(t, name), string(body))
+}
+
+func deleteSubscription(t *testing.T, name string) {
+	t.Helper()
+	sub := subscription(t, name)
+	if err := s.K8s.Client.Delete(s.Ctx, sub); err != nil {
+		t.Fatalf("deleting subscription %s: %v", name, err)
+	}
+	s.K8s.WaitAbsent(t, name, &gnmicv1alpha1.Subscription{})
+}
+
+func waitStreams(t *testing.T, want int) {
+	t.Helper()
+	for _, name := range allTargets {
+		s.GnmiGen.WaitStreams(t, name, want)
+	}
+}
+
+func waitPathOnAll(t *testing.T, path string) {
+	t.Helper()
+	for _, name := range allTargets {
+		s.GnmiGen.WaitPathPresent(t, name, path)
+	}
+}
+
+func waitPathAbsentOnAll(t *testing.T, path string) {
+	t.Helper()
+	for _, name := range allTargets {
+		s.GnmiGen.WaitPathAbsent(t, name, path)
+	}
+}
+
+func firstStream(t *testing.T, target string) harness.Subscription {
+	t.Helper()
+	var out harness.Subscription
+	harness.Wait(t, harness.Medium, fmt.Sprintf("one stream on %s", target), func() (bool, string) {
+		subs, err := s.GnmiGen.Subscriptions(target)
+		if err != nil {
+			return false, err.Error()
+		}
+		if len(subs) != 1 {
+			return false, fmt.Sprintf("got %d streams", len(subs))
+		}
+		out = subs[0]
+		return true, ""
+	})
+	return out
+}
+
+func waitEntryMode(t *testing.T, target, want string) {
+	t.Helper()
+	harness.Wait(t, harness.Medium, fmt.Sprintf("entry mode %s on %s", want, target), func() (bool, string) {
+		subs, err := s.GnmiGen.Subscriptions(target)
+		if err != nil {
+			return false, err.Error()
+		}
+		if len(subs) != 1 || len(subs[0].Entries) == 0 {
+			return false, fmt.Sprintf("streams=%d", len(subs))
+		}
+		got := subs[0].Entries[0].Mode
+		return got == want, fmt.Sprintf("got %s", got)
+	})
+}
+
+func waitEffectiveSample(t *testing.T, target, want string) {
+	t.Helper()
+	harness.Wait(t, harness.Medium, fmt.Sprintf("effective_sample_interval=%s on %s", want, target), func() (bool, string) {
+		subs, err := s.GnmiGen.Subscriptions(target)
+		if err != nil {
+			return false, err.Error()
+		}
+		if len(subs) != 1 {
+			return false, fmt.Sprintf("streams=%d", len(subs))
+		}
+		got := subs[0].EffectiveSampleInterval
+		if got != want {
+			return false, fmt.Sprintf("effective=%s", got)
+		}
+		if len(subs[0].Entries) == 0 {
+			return false, "no entries"
+		}
+		if entry := subs[0].Entries[0].SampleInterval; entry != want {
+			return false, fmt.Sprintf("entry=%s", entry)
+		}
+		return true, ""
+	})
+}
+
+func waitUpdatesOnly(t *testing.T, target string, want bool) {
+	t.Helper()
+	harness.Wait(t, harness.Medium, fmt.Sprintf("updates_only=%v on %s", want, target), func() (bool, string) {
+		subs, err := s.GnmiGen.Subscriptions(target)
+		if err != nil {
+			return false, err.Error()
+		}
+		if len(subs) != 1 {
+			return false, fmt.Sprintf("streams=%d", len(subs))
+		}
+		got := subs[0].UpdatesOnly
+		return got == want, fmt.Sprintf("got %v", got)
+	})
+}
+
+func waitSuppressAndHeartbeat(t *testing.T, target string, suppress bool, heartbeat string) {
+	t.Helper()
+	harness.Wait(t, harness.Medium, fmt.Sprintf("suppress=%v heartbeat=%s on %s", suppress, heartbeat, target), func() (bool, string) {
+		subs, err := s.GnmiGen.Subscriptions(target)
+		if err != nil {
+			return false, err.Error()
+		}
+		if len(subs) != 1 || len(subs[0].Entries) == 0 {
+			return false, fmt.Sprintf("streams=%d", len(subs))
+		}
+		e := subs[0].Entries[0]
+		if e.SuppressRedundant != suppress {
+			return false, fmt.Sprintf("suppress=%v", e.SuppressRedundant)
+		}
+		if heartbeat == "" {
+			if e.HeartbeatInterval != "" && e.HeartbeatInterval != "0s" {
+				return false, fmt.Sprintf("heartbeat still %s", e.HeartbeatInterval)
+			}
+			return true, ""
+		}
+		return e.HeartbeatInterval == heartbeat, fmt.Sprintf("heartbeat=%s", e.HeartbeatInterval)
+	})
+}
+
+func notificationDelta(target string, window time.Duration) int {
+	start := s.GnmiGen.Notifications(target)
+	time.Sleep(window)
+	return s.GnmiGen.Notifications(target) - start
+}
+
+func waitPromContains(t *testing.T, fragment string) {
+	t.Helper()
+	harness.Wait(t, harness.Medium, fmt.Sprintf("prometheus contains %s", fragment), func() (bool, string) {
+		body := s.K8s.ScrapeClusterPrometheus(t, cluster, pipeline, output)
+		if strings.Contains(body, fragment) {
+			return true, ""
+		}
+		return false, fmt.Sprintf("%d samples", harness.SampleCount(body))
+	})
+}
+
+func waitPromLacks(t *testing.T, fragment string) {
+	t.Helper()
+	harness.Wait(t, harness.Medium, fmt.Sprintf("prometheus lacks %s", fragment), func() (bool, string) {
+		body := s.K8s.ScrapeClusterPrometheus(t, cluster, pipeline, output)
+		if !strings.Contains(body, fragment) {
+			return true, ""
+		}
+		return false, "still present"
+	})
+}
+
+func TestSub001_PathChangeReplacesCollectedPaths(t *testing.T) {
+	waitIdle(t)
+	applySubscription(t, "s1", map[string]any{"Paths": []string{pathIF}})
+	waitStreams(t, 1)
+	waitPathOnAll(t, pathIF)
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	patchSubscription(t, "s1", map[string]any{"paths": []string{pathCPU}})
+
+	waitPathOnAll(t, pathCPU)
+	waitPathAbsentOnAll(t, pathIF)
+	waitStreams(t, 1)
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+
+	waitPromContains(t, "platform_control_process")
+	waitPromLacks(t, "interface_statistics")
+}
+
+func TestSub002_AddingPathExtendsSubscription(t *testing.T) {
+	waitIdle(t)
+	applySubscription(t, "s1", map[string]any{"Paths": []string{pathIF}})
+	waitStreams(t, 1)
+	waitPathOnAll(t, pathIF)
+	s.GnmiGen.WaitNotificationsAdvance(t, leaf1)
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	patchSubscription(t, "s1", map[string]any{"paths": []string{pathIF, pathCPU}})
+
+	waitPathOnAll(t, pathIF)
+	waitPathOnAll(t, pathCPU)
+	harness.Wait(t, harness.Medium, "resolved path count is 2", func() (bool, string) {
+		n := len(s.GnmiGen.Paths(leaf1))
+		return n >= 2, fmt.Sprintf("paths=%v", s.GnmiGen.Paths(leaf1))
+	})
+	// Path edits re-establish the Subscribe stream, which resets
+	// notifications_sent. Prove data still flows on the new stream rather
+	// than comparing absolute counters across the teardown.
+	s.GnmiGen.WaitNotificationsAdvance(t, leaf1)
+	waitStreams(t, 1)
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}
+
+func TestSub003_SampleIntervalChange(t *testing.T) {
+	waitIdle(t)
+	applySubscription(t, "s1", map[string]any{
+		"Paths":          []string{pathIF},
+		"SampleInterval": "10s",
+	})
+	waitStreams(t, 1)
+	waitEffectiveSample(t, leaf1, "10s")
+	slow := notificationDelta(leaf1, 10*time.Second)
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	patchSubscription(t, "s1", map[string]any{"sampleInterval": "2s"})
+	waitEffectiveSample(t, leaf1, "2s")
+	fast := notificationDelta(leaf1, 10*time.Second)
+
+	if fast <= slow {
+		t.Errorf("notification rate did not increase after interval shrink: slow=%d fast=%d over 10s", slow, fast)
+	}
+	waitStreams(t, 1)
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}
+
+func TestSub004_StreamModeChange(t *testing.T) {
+	waitIdle(t)
+	applySubscription(t, "s1", map[string]any{
+		"Mode":           "STREAM/SAMPLE",
+		"SampleInterval": "1s",
+		"Paths":          []string{pathIF},
+	})
+	waitStreams(t, 1)
+	waitEntryMode(t, leaf1, "SAMPLE")
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	patchSubscription(t, "s1", map[string]any{"mode": "STREAM/ON_CHANGE"})
+	waitEntryMode(t, leaf1, "ON_CHANGE")
+	waitStreams(t, 1)
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 10*time.Second, 1, allTargets...)
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}
+
+func TestSub005_UpdatesOnlyReachesWire(t *testing.T) {
+	waitIdle(t)
+	applySubscription(t, "s1", map[string]any{
+		"Paths":       []string{pathIF},
+		"UpdatesOnly": false,
+	})
+	waitStreams(t, 1)
+	waitUpdatesOnly(t, leaf1, false)
+	syncBefore := firstStream(t, leaf1).SyncMessagesSent
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	patchSubscription(t, "s1", map[string]any{"updatesOnly": true})
+	waitUpdatesOnly(t, leaf1, true)
+
+	// updatesOnly re-establishes the stream; sync pattern should differ from
+	// the initial full sync (typically sync_messages_sent stays 0 or much lower).
+	harness.Wait(t, harness.Medium, "updates_only stream settled", func() (bool, string) {
+		sub := firstStream(t, leaf1)
+		if !sub.UpdatesOnly {
+			return false, "updates_only still false"
+		}
+		return true, ""
+	})
+	syncAfter := firstStream(t, leaf1).SyncMessagesSent
+	if syncBefore == 0 && syncAfter == 0 {
+		t.Log("sync_messages_sent was 0 both before and after; flag still asserted on wire")
+	} else if syncAfter >= syncBefore && syncBefore > 0 {
+		// Soft signal only — gnmi-gen may still emit a sync response.
+		t.Logf("sync_messages_sent before=%d after=%d", syncBefore, syncAfter)
+	}
+	waitStreams(t, 1)
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}
+
+func TestSub006_SuppressRedundantAndHeartbeat(t *testing.T) {
+	waitIdle(t)
+	applySubscription(t, "s1", map[string]any{
+		"Paths":          []string{pathIF},
+		"SampleInterval": "1s",
+	})
+	waitStreams(t, 1)
+	waitSuppressAndHeartbeat(t, leaf1, false, "")
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	patchSubscription(t, "s1", map[string]any{
+		"suppressRedundant": true,
+		"heartbeatInterval": "30s",
+	})
+	waitSuppressAndHeartbeat(t, leaf1, true, "30s")
+
+	patchSubscription(t, "s1", map[string]any{
+		"suppressRedundant": false,
+		"heartbeatInterval": nil,
+	})
+	waitSuppressAndHeartbeat(t, leaf1, false, "")
+	waitStreams(t, 1)
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}
+
+func TestSub007_PerTargetSubscriptionScoped(t *testing.T) {
+	t.Skip("spec.target is the gNMI SubscribeRequest target field, not Target-CR scoping; CR-level pin is not implemented")
+}
+
+func TestSub008_PrefixApplied(t *testing.T) {
+	waitIdle(t)
+	applySubscription(t, "absolute", map[string]any{
+		"Paths": []string{pathIF},
+	})
+	waitStreams(t, 1)
+	waitPathOnAll(t, pathIF)
+	want := s.GnmiGen.Paths(leaf1)
+	deleteSubscription(t, "absolute")
+	// Last subscription gone: disable the pipeline so gNMIc accepts an empty
+	// apply and tears streams down (targets-without-subscriptions is invalid).
+	setPipelineEnabled(t, false)
+	waitStreams(t, 0)
+
+	applySubscription(t, "prefixed", map[string]any{
+		"Prefix":         "/interface",
+		"Paths":          []string{"/statistics"},
+		"SampleInterval": "1s",
+	})
+	waitStreams(t, 1)
+	waitPathOnAll(t, pathIF)
+	got := s.GnmiGen.Paths(leaf1)
+	if !samePathSet(want, got) {
+		t.Fatalf("prefix-joined paths %v do not match absolute paths %v", got, want)
+	}
+}
+
+func TestSub009_DeletingSubscriptionStopsPaths(t *testing.T) {
+	waitIdle(t)
+	applySubscription(t, "if", map[string]any{"Paths": []string{pathIF}})
+	applySubscription(t, "cpu", map[string]any{"Paths": []string{pathCPU}})
+	waitStreams(t, 2)
+	waitPathOnAll(t, pathIF)
+	waitPathOnAll(t, pathCPU)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		SubscriptionsCount: harness.I32(2),
+	})
+	s.GnmiGen.WaitNotificationsAdvance(t, leaf1)
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	deleteSubscription(t, "cpu")
+	waitPathAbsentOnAll(t, pathCPU)
+	waitPathOnAll(t, pathIF)
+	waitStreams(t, 1)
+	s.GnmiGen.WaitNotificationsAdvance(t, leaf1)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		SubscriptionsCount: harness.I32(1),
+	})
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+
+	deleteSubscription(t, "if")
+	setPipelineEnabled(t, false)
+	waitStreams(t, 0)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		SubscriptionsCount: harness.I32(0),
+	})
+}
+
+func TestSub010_RapidSuccessiveEditsConverge(t *testing.T) {
+	waitIdle(t)
+	applySubscription(t, "s1", map[string]any{"Paths": []string{pathIF}})
+	waitStreams(t, 1)
+	waitPathOnAll(t, pathIF)
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	since := time.Now()
+	paths := [][]string{
+		{pathCPU},
+		{pathSys},
+		{pathIF},
+		{pathCPU, pathSys},
+		{pathIF},
+	}
+	for _, p := range paths {
+		patchSubscription(t, "s1", map[string]any{"paths": p})
+	}
+
+	waitPathOnAll(t, pathIF)
+	waitPathAbsentOnAll(t, pathCPU)
+	waitPathAbsentOnAll(t, pathSys)
+	waitStreams(t, 1)
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 15*time.Second, 1, allTargets...)
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+	harness.AssertNoPanics(t, s.K8s.OperatorLogs(t, time.Since(since)+time.Minute))
+}
+
+func samePathSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, p := range a {
+		seen[p]++
+	}
+	for _, p := range b {
+		seen[p]--
+		if seen[p] < 0 {
+			return false
+		}
+	}
+	for _, n := range seen {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/test/integration/suite/005-outputs/fixtures/baseline.yaml
+++ b/test/integration/suite/005-outputs/fixtures/baseline.yaml
@@ -1,0 +1,75 @@
+# Shared props for 005-outputs. Pipelines and Outputs are created per test.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sim-credentials
+stringData:
+  username: gnmic
+  password: gnmic
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: TargetProfile
+metadata:
+  name: default
+spec:
+  credentialsRef: sim-credentials
+  encoding: JSON_IETF
+  timeout: 10s
+  tls: {}
+  retryTimer: 2s
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: c1
+spec:
+  image: {{ .GnmicImage }}
+  replicas: 1
+  api:
+    restPort: 7890
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: leaf1
+  labels:
+    vendor: gnmi-gen
+    role: leaf
+spec:
+  address: {{ .GnmiGenHost }}:57400
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: leaf2
+  labels:
+    vendor: gnmi-gen
+    role: leaf
+spec:
+  address: {{ .GnmiGenHost }}:57401
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: spine1
+  labels:
+    vendor: gnmi-gen
+    role: spine
+spec:
+  address: {{ .GnmiGenHost }}:57402
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: if-counters
+  labels:
+    suite: "005"
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 1s
+  encoding: JSON_IETF
+  paths:
+    - /interface/statistics/in-octets

--- a/test/integration/suite/005-outputs/fixtures/output-file.yaml
+++ b/test/integration/suite/005-outputs/fixtures/output-file.yaml
@@ -1,0 +1,11 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: {{ .Name }}
+  labels:
+    suite: "005"
+spec:
+  type: file
+  config:
+    filename: {{ .Filename }}
+    format: event

--- a/test/integration/suite/005-outputs/fixtures/output-prom.yaml
+++ b/test/integration/suite/005-outputs/fixtures/output-prom.yaml
@@ -1,0 +1,33 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: {{ .Name }}
+  labels:
+    suite: "005"
+{{- if .ExtraLabelKey }}
+    {{ .ExtraLabelKey }}: {{ .ExtraLabelValue }}
+{{- end }}
+spec:
+  type: prometheus
+{{- if .Expiration }}
+  config:
+    expiration: {{ .Expiration }}
+{{- else }}
+  config: {}
+{{- end }}
+{{- if .ServiceType }}
+  service:
+    type: {{ .ServiceType }}
+{{- if .ServiceLabels }}
+    labels:
+{{- range $k, $v := .ServiceLabels }}
+      {{ $k }}: {{ printf "%q" $v }}
+{{- end }}
+{{- end }}
+{{- if .ServiceAnnotations }}
+    annotations:
+{{- range $k, $v := .ServiceAnnotations }}
+      {{ $k }}: {{ printf "%q" $v }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/test/integration/suite/005-outputs/fixtures/pipeline.yaml
+++ b/test/integration/suite/005-outputs/fixtures/pipeline.yaml
@@ -1,0 +1,24 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: {{ .Name }}
+spec:
+  clusterRef: c1
+  enabled: true
+{{- if .TargetRole }}
+  targetSelectors:
+    - matchLabels:
+        role: {{ .TargetRole }}
+{{- else }}
+  targetSelectors:
+    - matchLabels:
+        vendor: gnmi-gen
+{{- end }}
+  subscriptionSelectors:
+    - matchLabels:
+        suite: "005"
+  outputs:
+    outputRefs:
+{{- range .OutputRefs }}
+      - {{ . }}
+{{- end }}

--- a/test/integration/suite/005-outputs/gnmi-gen.yaml
+++ b/test/integration/suite/005-outputs/gnmi-gen.yaml
@@ -1,0 +1,60 @@
+global:
+  seed: 42
+  shutdown_timeout: 5s
+
+api:
+  listen: 0.0.0.0:8080
+
+data_profiles:
+  interface_counter:
+    type: uint64
+    update_frequency: 1s
+    random:
+      distribution: counter
+      min: 100000
+      max: 900000
+      step_min: 100
+      step_max: 10000
+
+  system_name:
+    type: string
+    update_frequency: 10s
+    random:
+      value: leaf-{{.index}}
+
+  system_name_spine:
+    type: string
+    update_frequency: 10s
+    random:
+      value: spine-1
+
+servers:
+  - name: leaf{{.index}}
+    expand:
+      index:
+        start: 1
+        end: 2
+      listen:
+        host: 0.0.0.0
+        port_start: 57400
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name
+
+  - name: spine1
+    listen: 0.0.0.0:57402
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name_spine

--- a/test/integration/suite/005-outputs/outputs_test.go
+++ b/test/integration/suite/005-outputs/outputs_test.go
@@ -1,0 +1,389 @@
+//go:build integration
+
+// Package outputs covers Output CR binding: Prometheus Services, file output
+// delivery, dynamic edits, deletion, and per-pipeline Service naming.
+package outputs
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gnmicv1alpha1 "github.com/gnmic/operator/api/v1alpha1"
+	"github.com/gnmic/operator/test/integration/harness"
+)
+
+var s *harness.Suite
+
+const (
+	cluster = "c1"
+	leaf1   = "leaf1"
+	leaf2   = "leaf2"
+	spine1  = "spine1"
+	pathIF  = "/interface/statistics/in-octets"
+)
+
+var allTargets = []string{leaf1, leaf2, spine1}
+
+func TestMain(m *testing.M) {
+	os.Exit(harness.RunSuite(m, harness.Options{
+		Name:           "005-outputs",
+		RequireTargets: allTargets,
+		Baseline:       []string{"fixtures/baseline.yaml"},
+	}, &s))
+}
+
+func waitClusterReady(t *testing.T) {
+	t.Helper()
+	harness.WaitClusterReady(t, s.K8s, cluster)
+	s.K8s.WaitReadyPods(t, cluster, 1, harness.Long)
+}
+
+func waitIdle(t *testing.T) {
+	t.Helper()
+	var pipes gnmicv1alpha1.PipelineList
+	if err := s.K8s.Client.List(s.Ctx, &pipes, client.InNamespace(s.Namespace)); err == nil {
+		for i := range pipes.Items {
+			_ = s.K8s.Client.Delete(s.Ctx, &pipes.Items[i])
+		}
+	}
+	var outs gnmicv1alpha1.OutputList
+	if err := s.K8s.Client.List(s.Ctx, &outs, client.InNamespace(s.Namespace)); err == nil {
+		for i := range outs.Items {
+			_ = s.K8s.Client.Delete(s.Ctx, &outs.Items[i])
+		}
+	}
+	harness.Wait(t, harness.Medium, "pipelines gone", func() (bool, string) {
+		var left gnmicv1alpha1.PipelineList
+		if err := s.K8s.Client.List(s.Ctx, &left, client.InNamespace(s.Namespace)); err != nil {
+			return false, err.Error()
+		}
+		return len(left.Items) == 0, fmt.Sprintf("%d remain", len(left.Items))
+	})
+	harness.Wait(t, harness.Medium, "outputs gone", func() (bool, string) {
+		var left gnmicv1alpha1.OutputList
+		if err := s.K8s.Client.List(s.Ctx, &left, client.InNamespace(s.Namespace)); err != nil {
+			return false, err.Error()
+		}
+		return len(left.Items) == 0, fmt.Sprintf("%d remain", len(left.Items))
+	})
+	harness.Wait(t, harness.Medium, "targets idle", func() (bool, string) {
+		for _, name := range allTargets {
+			if n := s.GnmiGen.StreamCount(name); n != 0 {
+				return false, fmt.Sprintf("%s has %d streams", name, n)
+			}
+		}
+		return true, ""
+	})
+	s.K8s.WaitReadyPods(t, cluster, 1, harness.Long)
+}
+
+func applyPromOutput(t *testing.T, name string, vars map[string]any) {
+	t.Helper()
+	base := map[string]any{
+		"Name":               name,
+		"Expiration":         "",
+		"ServiceType":        "",
+		"ServiceLabels":      map[string]string{},
+		"ServiceAnnotations": map[string]string{},
+		"ExtraLabelKey":      "",
+		"ExtraLabelValue":    "",
+	}
+	for k, v := range vars {
+		base[k] = v
+	}
+	b, err := os.ReadFile("fixtures/output-prom.yaml")
+	if err != nil {
+		t.Fatalf("reading prom output fixture: %v", err)
+	}
+	if _, err := s.K8s.ApplyYAMLNoCleanup(string(b), base); err != nil {
+		t.Fatalf("applying prom output %s: %v", name, err)
+	}
+}
+
+func applyFileOutput(t *testing.T, name, filename string) {
+	t.Helper()
+	b, err := os.ReadFile("fixtures/output-file.yaml")
+	if err != nil {
+		t.Fatalf("reading file output fixture: %v", err)
+	}
+	if _, err := s.K8s.ApplyYAMLNoCleanup(string(b), map[string]any{
+		"Name":     name,
+		"Filename": filename,
+	}); err != nil {
+		t.Fatalf("applying file output %s: %v", name, err)
+	}
+}
+
+func applyPipeline(t *testing.T, name string, outputRefs []string, targetRole string) {
+	t.Helper()
+	b, err := os.ReadFile("fixtures/pipeline.yaml")
+	if err != nil {
+		t.Fatalf("reading pipeline fixture: %v", err)
+	}
+	if _, err := s.K8s.ApplyYAMLNoCleanup(string(b), map[string]any{
+		"Name":       name,
+		"OutputRefs": outputRefs,
+		"TargetRole": targetRole,
+	}); err != nil {
+		t.Fatalf("applying pipeline %s: %v", name, err)
+	}
+}
+
+func waitPromService(t *testing.T, pipe, out string) *corev1.Service {
+	t.Helper()
+	name := harness.PromServiceName(cluster, pipe, out)
+	svc := &corev1.Service{}
+	s.K8s.WaitExists(t, name, svc)
+	return s.K8s.Service(t, name)
+}
+
+func startPromPipeline(t *testing.T, pipe, out string) {
+	t.Helper()
+	applyPromOutput(t, out, nil)
+	applyPipeline(t, pipe, []string{out}, "")
+	waitClusterReady(t)
+	harness.WaitConfigApplied(t, s.K8s, cluster)
+	waitPromService(t, pipe, out)
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+}
+
+func TestOut001_PrometheusServiceShape(t *testing.T) {
+	waitIdle(t)
+	startPromPipeline(t, "p1", "out1")
+
+	svcName := harness.PromServiceName(cluster, "p1", "out1")
+	svc := s.K8s.Service(t, svcName)
+	if svc.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Errorf("type=%s want ClusterIP", svc.Spec.Type)
+	}
+	if got := svc.Spec.Selector[harness.LabelClusterName]; got != cluster {
+		t.Errorf("selector cluster=%q", got)
+	}
+	if len(svc.Spec.Ports) == 0 || svc.Spec.Ports[0].Port == 0 {
+		t.Fatal("expected allocated metrics port")
+	}
+	wantLabels := map[string]string{
+		harness.LabelServiceType:  harness.ValueServiceTypePrometheus,
+		harness.LabelOutputName:   "out1",
+		harness.LabelPipelineName: "p1",
+		harness.LabelClusterName:  cluster,
+	}
+	for k, v := range wantLabels {
+		if got := svc.Labels[k]; got != v {
+			t.Errorf("label %s=%q want %q", k, got, v)
+		}
+	}
+	harness.AssertOwnedBy(t, svc, "Cluster", cluster)
+}
+
+func TestOut002_PrometheusServesCollectedData(t *testing.T) {
+	waitIdle(t)
+	startPromPipeline(t, "p1", "out1")
+
+	s.K8s.WaitClusterPrometheusSources(t, cluster, "p1", "out1", allTargets, harness.Medium)
+	body1 := s.K8s.ScrapeClusterPrometheus(t, cluster, "p1", "out1")
+	n1 := harness.SampleCount(body1)
+	if n1 == 0 {
+		t.Fatal("expected samples")
+	}
+	if !strings.Contains(body1, "interface_statistics") && !strings.Contains(body1, "in_octets") {
+		t.Errorf("scrape missing interface path metrics; samples=%d", n1)
+	}
+	time.Sleep(10 * time.Second)
+	body2 := s.K8s.ScrapeClusterPrometheus(t, cluster, "p1", "out1")
+	n2 := harness.SampleCount(body2)
+	if n2 < n1 {
+		t.Errorf("sample count shrank between scrapes: %d -> %d", n1, n2)
+	}
+	s.K8s.WaitClusterPrometheusSources(t, cluster, "p1", "out1", allTargets, harness.Short)
+}
+
+func TestOut003_ServiceTypeHonored(t *testing.T) {
+	waitIdle(t)
+	applyPromOutput(t, "out1", map[string]any{
+		"ServiceType": "NodePort",
+		"ServiceLabels": map[string]string{
+			"team":                          "telemetry",
+			harness.LabelServiceType:        "should-not-win",
+			"app.kubernetes.io/managed-by":  "user",
+		},
+		"ServiceAnnotations": map[string]string{
+			"custom.annotation":    "yes",
+			"prometheus.io/scrape": "false",
+		},
+	})
+	applyPipeline(t, "p1", []string{"out1"}, "")
+	waitClusterReady(t)
+
+	svc := s.K8s.Service(t, harness.PromServiceName(cluster, "p1", "out1"))
+	if svc.Spec.Type != corev1.ServiceTypeNodePort {
+		t.Fatalf("type=%s want NodePort", svc.Spec.Type)
+	}
+	if svc.Spec.Ports[0].NodePort == 0 {
+		t.Fatal("expected allocated node port")
+	}
+	if svc.Labels["team"] != "telemetry" {
+		t.Errorf("user label missing: %v", svc.Labels)
+	}
+	if svc.Labels[harness.LabelServiceType] != harness.ValueServiceTypePrometheus {
+		t.Errorf("operator service-type overwritten: %q", svc.Labels[harness.LabelServiceType])
+	}
+	if svc.Labels["app.kubernetes.io/managed-by"] != harness.ValueManagedBy {
+		t.Errorf("operator managed-by overwritten: %q", svc.Labels["app.kubernetes.io/managed-by"])
+	}
+	if svc.Annotations["custom.annotation"] != "yes" {
+		t.Errorf("user annotation missing: %v", svc.Annotations)
+	}
+	if svc.Annotations["prometheus.io/scrape"] != "true" {
+		t.Errorf("operator scrape annotation overwritten: %q", svc.Annotations["prometheus.io/scrape"])
+	}
+}
+
+func TestOut004_FileOutputWritesInPod(t *testing.T) {
+	waitIdle(t)
+	const file = "/tmp/005-out.jsonl"
+	applyFileOutput(t, "file1", file)
+	applyPipeline(t, "p1", []string{"file1"}, "")
+	waitClusterReady(t)
+
+	events := s.K8s.WaitEventsHaveSources(t, cluster, file, allTargets...)
+	if len(events) == 0 {
+		t.Fatal("no parseable events in file output")
+	}
+
+	// No Prometheus Service as a side effect of a file output.
+	svcName := harness.PromServiceName(cluster, "p1", "file1")
+	var svc corev1.Service
+	err := s.K8s.Client.Get(s.Ctx, types.NamespacedName{Namespace: s.Namespace, Name: svcName}, &svc)
+	if err == nil {
+		t.Fatalf("unexpected prometheus service %s for file output", svcName)
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("getting %s: %v", svcName, err)
+	}
+}
+
+func TestOut005_EditingOutputNoRestart(t *testing.T) {
+	waitIdle(t)
+	const oldFile = "/tmp/005-old.jsonl"
+	const newFile = "/tmp/005-new.jsonl"
+	applyFileOutput(t, "file1", oldFile)
+	applyPromOutput(t, "out1", map[string]any{"Expiration": "60s"})
+	applyPipeline(t, "p1", []string{"file1", "out1"}, "")
+	waitClusterReady(t)
+	s.K8s.WaitCollectorFileNonEmpty(t, cluster, oldFile)
+	s.K8s.WaitClusterPrometheusSources(t, cluster, "p1", "out1", allTargets, harness.Medium)
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	oldLen := len(s.K8s.ReadCollectorFile(t, cluster, oldFile))
+
+	out := &gnmicv1alpha1.Output{}
+	s.K8s.WaitExists(t, "file1", out)
+	s.K8s.Patch(t, out, fmt.Sprintf(`{"spec":{"config":{"filename":%q,"format":"event"}}}`, newFile))
+
+	prom := &gnmicv1alpha1.Output{}
+	s.K8s.WaitExists(t, "out1", prom)
+	s.K8s.Patch(t, prom, `{"spec":{"config":{"expiration":"120s"}}}`)
+
+	harness.WaitConfigApplied(t, s.K8s, cluster)
+	s.K8s.WaitCollectorFileNonEmpty(t, cluster, newFile)
+	s.K8s.WaitClusterPrometheusSources(t, cluster, "p1", "out1", allTargets, harness.Medium)
+
+	// Old file should stop growing once the output points elsewhere.
+	time.Sleep(3 * time.Second)
+	if got := len(s.K8s.ReadCollectorFile(t, cluster, oldFile)); got > oldLen+64 {
+		t.Errorf("old file still growing: was %d now %d", oldLen, got)
+	}
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}
+
+func TestOut006_DeletingOutputRemovesService(t *testing.T) {
+	waitIdle(t)
+	startPromPipeline(t, "p1", "out1")
+	svcName := harness.PromServiceName(cluster, "p1", "out1")
+	_ = s.K8s.Service(t, svcName)
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	out := &gnmicv1alpha1.Output{}
+	s.K8s.WaitExists(t, "out1", out)
+	if err := s.K8s.Client.Delete(s.Ctx, out); err != nil {
+		t.Fatalf("deleting output: %v", err)
+	}
+	s.K8s.WaitAbsent(t, "out1", &gnmicv1alpha1.Output{})
+	s.K8s.WaitAbsent(t, svcName, &corev1.Service{})
+
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		OutputsCount: harness.I32(0),
+	})
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 10*time.Second, 1, allTargets...)
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}
+
+func TestOut007_SharedOutputTwoServices(t *testing.T) {
+	waitIdle(t)
+	applyPromOutput(t, "out1", nil)
+	applyPipeline(t, "p1", []string{"out1"}, "leaf")
+	applyPipeline(t, "p2", []string{"out1"}, "spine")
+	waitClusterReady(t)
+	harness.WaitConfigApplied(t, s.K8s, cluster)
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		PipelinesCount: harness.I32(2),
+		TargetsCount:   harness.I32(3),
+		OutputsCount:   harness.I32(2), // per-pipeline output bindings
+	})
+
+	// Cluster Ready can still be true from the idle empty plan; wait for the
+	// Services themselves before asserting on them.
+	svc1 := waitPromService(t, "p1", "out1")
+	svc2 := waitPromService(t, "p2", "out1")
+	if svc1.Spec.Ports[0].Port == svc2.Spec.Ports[0].Port {
+		t.Fatalf("expected distinct ports, both %d", svc1.Spec.Ports[0].Port)
+	}
+
+	s.K8s.WaitClusterPrometheusSources(t, cluster, "p1", "out1", []string{leaf1, leaf2}, harness.Medium)
+	s.K8s.WaitClusterPrometheusSources(t, cluster, "p2", "out1", []string{spine1}, harness.Medium)
+
+	// Isolation: each pipeline's prometheus port must not carry the other
+	// pipeline's targets (shared Subscription CR, disjoint target selectors).
+	harness.Wait(t, harness.Medium, "p1 lacks spine1", func() (bool, string) {
+		body, err := s.K8s.ScrapeClusterPrometheusQuiet(cluster, "p1", "out1")
+		if err != nil {
+			return false, err.Error()
+		}
+		if harness.HasLabel(body, spine1) {
+			return false, "spine1 still present"
+		}
+		return true, ""
+	})
+	harness.Wait(t, harness.Medium, "p2 lacks leaves", func() (bool, string) {
+		body, err := s.K8s.ScrapeClusterPrometheusQuiet(cluster, "p2", "out1")
+		if err != nil {
+			return false, err.Error()
+		}
+		if harness.HasLabel(body, leaf1) || harness.HasLabel(body, leaf2) {
+			return false, "leaf still present"
+		}
+		return true, ""
+	})
+
+	pipe := s.K8s.Pipeline(t, "p2")
+	if err := s.K8s.Client.Delete(s.Ctx, pipe); err != nil {
+		t.Fatalf("deleting p2: %v", err)
+	}
+	s.K8s.WaitAbsent(t, "p2", &gnmicv1alpha1.Pipeline{})
+	s.K8s.WaitAbsent(t, harness.PromServiceName(cluster, "p2", "out1"), &corev1.Service{})
+	_ = s.K8s.Service(t, harness.PromServiceName(cluster, "p1", "out1"))
+	s.K8s.WaitClusterPrometheusSources(t, cluster, "p1", "out1", []string{leaf1, leaf2}, harness.Medium)
+}
+
+func TestOut008_ServiceRefResolvesAddress(t *testing.T) {
+	t.Skip("prometheus_write sink fixture deferred; see Planned 005-8")
+}

--- a/test/integration/suite/006-processors/fixtures/baseline.yaml
+++ b/test/integration/suite/006-processors/fixtures/baseline.yaml
@@ -1,0 +1,84 @@
+# Shared props for 006-processors. Processors and Pipelines are created per test.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sim-credentials
+stringData:
+  username: gnmic
+  password: gnmic
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: TargetProfile
+metadata:
+  name: default
+spec:
+  credentialsRef: sim-credentials
+  encoding: JSON_IETF
+  timeout: 10s
+  tls: {}
+  retryTimer: 2s
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: c1
+spec:
+  image: {{ .GnmicImage }}
+  replicas: 1
+  api:
+    restPort: 7890
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: leaf1
+  labels:
+    vendor: gnmi-gen
+spec:
+  address: {{ .GnmiGenHost }}:57400
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: leaf2
+  labels:
+    vendor: gnmi-gen
+spec:
+  address: {{ .GnmiGenHost }}:57401
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: spine1
+  labels:
+    vendor: gnmi-gen
+spec:
+  address: {{ .GnmiGenHost }}:57402
+  profile: default
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: if-counters
+  labels:
+    suite: "006"
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 1s
+  encoding: JSON_IETF
+  paths:
+    - /interface/statistics/in-octets
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: sink
+  labels:
+    suite: "006"
+spec:
+  type: file
+  config:
+    filename: /tmp/out.jsonl
+    format: event

--- a/test/integration/suite/006-processors/fixtures/pipeline.yaml
+++ b/test/integration/suite/006-processors/fixtures/pipeline.yaml
@@ -1,0 +1,27 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: {{ .Name }}
+spec:
+  clusterRef: c1
+  enabled: true
+  targetSelectors:
+    - matchLabels:
+        vendor: gnmi-gen
+  subscriptionSelectors:
+    - matchLabels:
+        suite: "006"
+  outputs:
+    outputRefs:
+      - sink
+{{- if .ProcessorChain }}
+    processorSelectors:
+      - matchLabels:
+          chain: {{ .ProcessorChain }}
+{{- end }}
+{{- if .ProcessorRefs }}
+    processorRefs:
+{{- range .ProcessorRefs }}
+      - {{ . }}
+{{- end }}
+{{- end }}

--- a/test/integration/suite/006-processors/fixtures/processor-add-tag.yaml
+++ b/test/integration/suite/006-processors/fixtures/processor-add-tag.yaml
@@ -1,0 +1,17 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Processor
+metadata:
+  name: {{ .Name }}
+  labels:
+    suite: "006"
+{{- if .Chain }}
+    chain: {{ .Chain }}
+{{- end }}
+spec:
+  type: event-add-tag
+  config:
+    # Without a matcher, gNMIc never adds tags (see event-add-tag docs).
+    value-names:
+      - "."
+    add:
+      {{ .TagKey }}: {{ .TagValue }}

--- a/test/integration/suite/006-processors/fixtures/processor-jq.yaml
+++ b/test/integration/suite/006-processors/fixtures/processor-jq.yaml
@@ -1,0 +1,15 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Processor
+metadata:
+  name: {{ .Name }}
+  labels:
+    suite: "006"
+{{- if .Chain }}
+    chain: {{ .Chain }}
+{{- end }}
+spec:
+  type: event-jq
+  config:
+    # condition is evaluated per event (single object), not the notification array.
+    condition: '.tags.stage != null'
+    expression: '.[] |= (.tags.stage = "second")'

--- a/test/integration/suite/006-processors/gnmi-gen.yaml
+++ b/test/integration/suite/006-processors/gnmi-gen.yaml
@@ -1,0 +1,60 @@
+global:
+  seed: 42
+  shutdown_timeout: 5s
+
+api:
+  listen: 0.0.0.0:8080
+
+data_profiles:
+  interface_counter:
+    type: uint64
+    update_frequency: 1s
+    random:
+      distribution: counter
+      min: 100000
+      max: 900000
+      step_min: 100
+      step_max: 10000
+
+  system_name:
+    type: string
+    update_frequency: 10s
+    random:
+      value: leaf-{{.index}}
+
+  system_name_spine:
+    type: string
+    update_frequency: 10s
+    random:
+      value: spine-1
+
+servers:
+  - name: leaf{{.index}}
+    expand:
+      index:
+        start: 1
+        end: 2
+      listen:
+        host: 0.0.0.0
+        port_start: 57400
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name
+
+  - name: spine1
+    listen: 0.0.0.0:57402
+    tls: {}
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name_spine

--- a/test/integration/suite/006-processors/processors_test.go
+++ b/test/integration/suite/006-processors/processors_test.go
@@ -1,0 +1,279 @@
+//go:build integration
+
+// Package processors covers Processor binding and ordering on Pipeline outputs.
+package processors
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gnmicv1alpha1 "github.com/gnmic/operator/api/v1alpha1"
+	"github.com/gnmic/operator/test/integration/harness"
+)
+
+var s *harness.Suite
+
+const (
+	cluster = "c1"
+	leaf1   = "leaf1"
+	leaf2   = "leaf2"
+	spine1  = "spine1"
+	outFile = "/tmp/out.jsonl"
+)
+
+var allTargets = []string{leaf1, leaf2, spine1}
+
+func TestMain(m *testing.M) {
+	os.Exit(harness.RunSuite(m, harness.Options{
+		Name:           "006-processors",
+		RequireTargets: allTargets,
+		Baseline:       []string{"fixtures/baseline.yaml"},
+	}, &s))
+}
+
+func waitClusterReady(t *testing.T) {
+	t.Helper()
+	harness.WaitClusterReady(t, s.K8s, cluster)
+	s.K8s.WaitReadyPods(t, cluster, 1, harness.Long)
+}
+
+func waitIdle(t *testing.T) {
+	t.Helper()
+	var pipes gnmicv1alpha1.PipelineList
+	if err := s.K8s.Client.List(s.Ctx, &pipes, client.InNamespace(s.Namespace)); err == nil {
+		for i := range pipes.Items {
+			_ = s.K8s.Client.Delete(s.Ctx, &pipes.Items[i])
+		}
+	}
+	var procs gnmicv1alpha1.ProcessorList
+	if err := s.K8s.Client.List(s.Ctx, &procs, client.InNamespace(s.Namespace)); err == nil {
+		for i := range procs.Items {
+			_ = s.K8s.Client.Delete(s.Ctx, &procs.Items[i])
+		}
+	}
+	harness.Wait(t, harness.Medium, "pipelines gone", func() (bool, string) {
+		var left gnmicv1alpha1.PipelineList
+		if err := s.K8s.Client.List(s.Ctx, &left, client.InNamespace(s.Namespace)); err != nil {
+			return false, err.Error()
+		}
+		return len(left.Items) == 0, fmt.Sprintf("%d remain", len(left.Items))
+	})
+	harness.Wait(t, harness.Medium, "processors gone", func() (bool, string) {
+		var left gnmicv1alpha1.ProcessorList
+		if err := s.K8s.Client.List(s.Ctx, &left, client.InNamespace(s.Namespace)); err != nil {
+			return false, err.Error()
+		}
+		return len(left.Items) == 0, fmt.Sprintf("%d remain", len(left.Items))
+	})
+	harness.Wait(t, harness.Medium, "targets idle", func() (bool, string) {
+		for _, name := range allTargets {
+			if n := s.GnmiGen.StreamCount(name); n != 0 {
+				return false, fmt.Sprintf("%s has %d streams", name, n)
+			}
+		}
+		return true, ""
+	})
+	// Collector may still be Pending right after baseline; wait before exec.
+	s.K8s.WaitReadyPods(t, cluster, 1, harness.Long)
+	pod := s.K8s.FirstCollectorPod(t, cluster)
+	_ = s.K8s.Exec(t, pod, harness.CollectorContainer, "sh", "-c", fmt.Sprintf("rm -f %q", outFile))
+}
+
+func applyAddTag(t *testing.T, name, chain, key, value string) {
+	t.Helper()
+	b, err := os.ReadFile("fixtures/processor-add-tag.yaml")
+	if err != nil {
+		t.Fatalf("reading add-tag fixture: %v", err)
+	}
+	if _, err := s.K8s.ApplyYAMLNoCleanup(string(b), map[string]any{
+		"Name":     name,
+		"Chain":    chain,
+		"TagKey":   key,
+		"TagValue": value,
+	}); err != nil {
+		t.Fatalf("applying processor %s: %v", name, err)
+	}
+}
+
+func applyJQ(t *testing.T, name, chain string) {
+	t.Helper()
+	b, err := os.ReadFile("fixtures/processor-jq.yaml")
+	if err != nil {
+		t.Fatalf("reading jq fixture: %v", err)
+	}
+	if _, err := s.K8s.ApplyYAMLNoCleanup(string(b), map[string]any{
+		"Name":  name,
+		"Chain": chain,
+	}); err != nil {
+		t.Fatalf("applying processor %s: %v", name, err)
+	}
+}
+
+func applyPipeline(t *testing.T, name, chain string, refs []string) {
+	t.Helper()
+	if refs == nil {
+		refs = []string{}
+	}
+	b, err := os.ReadFile("fixtures/pipeline.yaml")
+	if err != nil {
+		t.Fatalf("reading pipeline fixture: %v", err)
+	}
+	if _, err := s.K8s.ApplyYAMLNoCleanup(string(b), map[string]any{
+		"Name":           name,
+		"ProcessorChain": chain,
+		"ProcessorRefs":  refs,
+	}); err != nil {
+		t.Fatalf("applying pipeline %s: %v", name, err)
+	}
+}
+
+func startBound(t *testing.T, chain string) {
+	t.Helper()
+	applyPipeline(t, "p1", chain, nil)
+	waitClusterReady(t)
+	harness.WaitConfigApplied(t, s.K8s, cluster)
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+}
+
+func TestProc001_SelectedProcessorApplied(t *testing.T) {
+	waitIdle(t)
+	applyAddTag(t, "add-env", "a", "env", "test")
+	startBound(t, "a")
+
+	events := s.K8s.WaitEventsHaveTag(t, cluster, outFile, "env", "test")
+	if !harness.EventsHaveSource(events, leaf1) {
+		t.Errorf("processor replaced rather than added tags; events=%+v", events[:min(3, len(events))])
+	}
+	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
+		PipelinesCount:     harness.I32(1),
+		TargetsCount:       harness.I32(3),
+		SubscriptionsCount: harness.I32(1),
+		OutputsCount:       harness.I32(1),
+	})
+}
+
+func TestProc002_UnboundProcessorNotApplied(t *testing.T) {
+	waitIdle(t)
+	applyAddTag(t, "add-a", "a", "env", "alpha")
+	applyAddTag(t, "add-b", "b", "env", "beta")
+	startBound(t, "a")
+
+	s.K8s.WaitEventsHaveTag(t, cluster, outFile, "env", "alpha")
+	s.K8s.ConsistentlyEventsLackTag(t, cluster, outFile, "env", "beta", 15*time.Second)
+}
+
+func TestProc003_ProcessorOrderDeterministic(t *testing.T) {
+	waitIdle(t)
+	// Selector order is by name: add-stage then rewrite-stage.
+	// add sets stage=first; jq rewrites to second only if stage is already set.
+	// Documented order therefore yields stage=second.
+	applyAddTag(t, "add-stage", "ord", "stage", "first")
+	applyJQ(t, "rewrite-stage", "ord")
+
+	var got string
+	for i := 0; i < 3; i++ {
+		if i > 0 {
+			pipe := s.K8s.Pipeline(t, "p1")
+			_ = s.K8s.Client.Delete(s.Ctx, pipe)
+			s.K8s.WaitAbsent(t, "p1", &gnmicv1alpha1.Pipeline{})
+			pod := s.K8s.FirstCollectorPod(t, cluster)
+			_ = s.K8s.Exec(t, pod, harness.CollectorContainer, "sh", "-c", fmt.Sprintf("rm -f %q", outFile))
+			harness.Wait(t, harness.Medium, "idle between recreates", func() (bool, string) {
+				for _, name := range allTargets {
+					if n := s.GnmiGen.StreamCount(name); n != 0 {
+						return false, fmt.Sprintf("%s=%d", name, n)
+					}
+				}
+				return true, ""
+			})
+		}
+		startBound(t, "ord")
+		events := s.K8s.WaitEventsHaveTag(t, cluster, outFile, "stage", "second")
+		if harness.EventsHaveTag(events, "stage", "first") && !harness.EventsHaveTag(events, "stage", "second") {
+			t.Fatalf("run %d: got stage=first (jq-before-add), want stage=second", i+1)
+		}
+		if !harness.EventsHaveTag(events, "stage", "second") {
+			t.Fatalf("run %d: missing stage=second", i+1)
+		}
+		if got == "" {
+			got = "second"
+		} else if got != "second" {
+			t.Fatalf("non-deterministic order across recreates")
+		}
+	}
+}
+
+func TestProc004_AddingProcessorLive(t *testing.T) {
+	waitIdle(t)
+	applyAddTag(t, "add-a", "a", "env", "alpha")
+	applyAddTag(t, "add-b", "", "zone", "z1") // unbound until labelled
+	startBound(t, "a")
+	s.K8s.WaitEventsHaveTag(t, cluster, outFile, "env", "alpha")
+	before := s.K8s.ReadCollectorFile(t, cluster, outFile)
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	proc := &gnmicv1alpha1.Processor{}
+	s.K8s.WaitExists(t, "add-b", proc)
+	s.K8s.Patch(t, proc, `{"metadata":{"labels":{"chain":"a"}}}`)
+
+	harness.WaitConfigApplied(t, s.K8s, cluster)
+	s.K8s.WaitEventsHaveTag(t, cluster, outFile, "zone", "z1")
+	after := s.K8s.ReadCollectorFile(t, cluster, outFile)
+	if !harness.EventsHaveTag(harness.ParseEvents(before), "env", "alpha") {
+		t.Fatal("expected earlier lines to retain env=alpha")
+	}
+	if harness.EventsHaveTag(harness.ParseEvents(before), "zone", "z1") {
+		t.Fatal("zone tag appeared before the live edit")
+	}
+	if !harness.EventsHaveTag(harness.ParseEvents(after), "zone", "z1") {
+		t.Fatal("zone tag missing after live edit")
+	}
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}
+
+func TestProc005_RemovingProcessorStopsTransform(t *testing.T) {
+	waitIdle(t)
+	applyAddTag(t, "add-a", "a", "env", "alpha")
+	applyAddTag(t, "add-b", "a", "zone", "z1")
+	startBound(t, "a")
+	s.K8s.WaitEventsHaveTag(t, cluster, outFile, "env", "alpha")
+	s.K8s.WaitEventsHaveTag(t, cluster, outFile, "zone", "z1")
+
+	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	mark := len(s.K8s.ReadCollectorFile(t, cluster, outFile))
+
+	proc := &gnmicv1alpha1.Processor{}
+	s.K8s.WaitExists(t, "add-b", proc)
+	s.K8s.Patch(t, proc, `{"metadata":{"labels":{"chain":null}}}`)
+	harness.WaitConfigApplied(t, s.K8s, cluster)
+
+	// Wait for new events that have env but not zone.
+	harness.Wait(t, harness.Medium, "new events without zone", func() (bool, string) {
+		body := s.K8s.ReadCollectorFile(t, cluster, outFile)
+		if len(body) <= mark {
+			return false, "no new bytes"
+		}
+		tail := harness.ParseEvents(body[mark:])
+		if len(tail) == 0 {
+			return false, "no new events"
+		}
+		if harness.EventsHaveTag(tail, "zone", "z1") {
+			return false, "zone still present in new events"
+		}
+		return harness.EventsHaveTag(tail, "env", "alpha"), "env missing"
+	})
+
+	proc = &gnmicv1alpha1.Processor{}
+	s.K8s.WaitExists(t, "add-b", proc)
+	if err := s.K8s.Client.Delete(s.Ctx, proc); err != nil {
+		t.Fatalf("deleting processor: %v", err)
+	}
+	s.K8s.WaitAbsent(t, "add-b", &gnmicv1alpha1.Processor{})
+
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 10*time.Second, 1, allTargets...)
+	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
+}

--- a/test/integration/suite/008-distribution/distribution_test.go
+++ b/test/integration/suite/008-distribution/distribution_test.go
@@ -486,7 +486,14 @@ func TestDist008_NoDoubleCollectionDuringScale(t *testing.T) {
 	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
 }
 
-// TestDist009_PodDeletionRecoversAssignments checks unplanned pod loss.
+// TestDist009_PodDeletionRecoversAssignments checks unplanned pod loss, and
+// that the apply-cache record for the dead pod is invalidated so the
+// recreated pod is re-configured.
+//
+// The Cluster controller fingerprints each pod's apply payload and skips the
+// POST when the hash matches. A restart leaves the desired plan unchanged, so
+// without invalidation (TargetState SSE disconnect) the short-circuit would
+// skip the re-apply forever and the victim's targets would stay uncollected.
 func TestDist009_PodDeletionRecoversAssignments(t *testing.T) {
 	const cluster = "poddel"
 	startCluster(t, cluster, 3, 0, allTargets)
@@ -495,24 +502,66 @@ func TestDist009_PodDeletionRecoversAssignments(t *testing.T) {
 	estab := establishedSnapshot(allTargets)
 	victim := harness.PodName(cluster, 1)
 
+	var owned, survivors []string
+	for _, name := range allTargets {
+		switch before[name] {
+		case victim:
+			owned = append(owned, name)
+		case "":
+			t.Fatalf("%s has no owner before deletion", name)
+		default:
+			survivors = append(survivors, name)
+		}
+	}
+	if len(owned) == 0 {
+		t.Fatalf("%s owns no targets; cannot assert re-apply", victim)
+	}
+
 	pod := &corev1.Pod{}
 	pod.Name = victim
 	pod.Namespace = s.Namespace
 	// The StatefulSet recreates the pod immediately, so do not wait for absence.
 	s.K8s.DeleteNow(t, pod)
 
+	// Prove the restart emptied the victim's work before asserting recovery.
+	for _, name := range owned {
+		s.GnmiGen.WaitStreams(t, name, 0)
+	}
+
 	s.K8s.WaitReadyPods(t, cluster, 3, harness.Long)
 	waitAssigned(t, cluster, allTargets)
 	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{ReadyReplicas: harness.I32(3)})
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
 
 	after := assignments(t, cluster, allTargets)
-	for tgt, pod := range after {
-		if pod == "" {
-			t.Errorf("%s has no owner after recovery", tgt)
+	for _, name := range owned {
+		if after[name] == "" {
+			t.Errorf("%s has no owner after recovery", name)
 		}
 	}
-	assertEstablishedPreserved(t, estab, before, after)
-	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+
+	// Survivors must not have been churned by the re-apply of the victim.
+	survivorBefore := map[string]string{}
+	survivorAfter := map[string]string{}
+	for _, name := range survivors {
+		survivorBefore[name] = before[name]
+		survivorAfter[name] = after[name]
+	}
+	assertEstablishedPreserved(t, estab, survivorBefore, survivorAfter)
+
+	// Victim's targets must be new streams — same pod name, new process.
+	for _, name := range owned {
+		was := estab[name]
+		now := s.GnmiGen.EstablishedAt(name)
+		if was.IsZero() || now.IsZero() {
+			t.Errorf("%s missing established_at before=%v after=%v", name, was, now)
+			continue
+		}
+		if now.Sub(was).Abs() <= time.Second {
+			t.Errorf("%s stream survived pod restart on %s (established_at=%s); config was not re-applied",
+				name, victim, now)
+		}
+	}
 }
 
 // TestDist010_AddingTargetDoesNotChurnExisting checks membership growth is
@@ -596,4 +645,37 @@ spec:
 	}
 	assertEstablishedPreserved(t, estab, before, after)
 	s.GnmiGen.AssertCollectedOnce(t, 1, rest...)
+}
+
+// TestDist012_AssignmentSurvivesOperatorRestart checks placement is
+// deterministic across a manager restart. Runs last in this package: it
+// restarts the shared controller in gnmic-system.
+//
+// An empty apply-cache after restart means every pod is re-configured once, so
+// streams may refresh; the assert is that owners do not reshuffle and the
+// collected-once invariant holds after the manager is back.
+func TestDist012_AssignmentSurvivesOperatorRestart(t *testing.T) {
+	const cluster = "oprestart"
+	startCluster(t, cluster, 3, 0, allTargets)
+
+	before := assignments(t, cluster, allTargets)
+	assertBalanced(t, before, 3)
+	assertDisjoint(t, before)
+
+	s.K8s.RestartOperator(t)
+
+	harness.WaitClusterReady(t, s.K8s, cluster)
+	s.K8s.WaitReadyPods(t, cluster, 3, harness.Long)
+	waitAssigned(t, cluster, allTargets)
+	s.GnmiGen.AssertCollectedOnce(t, 1, allTargets...)
+
+	after := assignments(t, cluster, allTargets)
+	for _, name := range allTargets {
+		if before[name] != after[name] {
+			t.Errorf("%s reshuffled: %q -> %q", name, before[name], after[name])
+		}
+	}
+	assertBalanced(t, after, 3)
+	assertDisjoint(t, after)
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 10*time.Second, 1, allTargets...)
 }

--- a/test/integration/suite/010-tls/fixtures/baseline.yaml
+++ b/test/integration/suite/010-tls/fixtures/baseline.yaml
@@ -1,0 +1,59 @@
+# Shared props for 010-tls. Profiles and Targets are created per test; the
+# Cluster starts without TLS so individual tests can opt into clientTLS / api.tls.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sim-credentials
+stringData:
+  username: gnmic
+  password: gnmic
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: c1
+spec:
+  image: {{ .GnmicImage }}
+  replicas: 1
+  api:
+    restPort: 7890
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: if-counters
+  labels:
+    suite: "010"
+spec:
+  mode: STREAM/SAMPLE
+  sampleInterval: 1s
+  encoding: JSON_IETF
+  paths:
+    - /interface/statistics/in-octets
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Output
+metadata:
+  name: prom
+  labels:
+    suite: "010"
+spec:
+  type: prometheus
+---
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: collect
+spec:
+  clusterRef: c1
+  enabled: true
+  targetSelectors:
+    - matchLabels:
+        suite: "010"
+  subscriptionSelectors:
+    - matchLabels:
+        suite: "010"
+  outputs:
+    outputSelectors:
+      - matchLabels:
+          suite: "010"

--- a/test/integration/suite/010-tls/fixtures/cluster.yaml
+++ b/test/integration/suite/010-tls/fixtures/cluster.yaml
@@ -1,0 +1,22 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: {{ .Name }}
+spec:
+  image: {{ .GnmicImage }}
+  replicas: {{ .Replicas }}
+  api:
+    restPort: {{ .RestPort }}
+{{- if .APIIssuer }}
+    tls:
+      issuerRef: {{ .APIIssuer }}
+{{- end }}
+{{- if or .ClientIssuer .BundleRef }}
+  clientTLS:
+{{- if .ClientIssuer }}
+    issuerRef: {{ .ClientIssuer }}
+{{- end }}
+{{- if .BundleRef }}
+    bundleRef: {{ .BundleRef }}
+{{- end }}
+{{- end }}

--- a/test/integration/suite/010-tls/fixtures/gnmi-gen-server-cert.yaml
+++ b/test/integration/suite/010-tls/fixtures/gnmi-gen-server-cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gnmi-gen-server
+spec:
+  secretName: gnmi-gen-server-tls
+  commonName: gnmi-gen
+  dnsNames:
+    - gnmi-gen
+    - gnmi-gen.{{ .Namespace }}
+    - gnmi-gen.{{ .Namespace }}.svc
+    - gnmi-gen.{{ .Namespace }}.svc.cluster.local
+    - {{ .GnmiGenHost }}
+  usages:
+    - server auth
+    - digital signature
+    - key encipherment
+  issuerRef:
+    name: suite-ca-issuer
+    kind: Issuer

--- a/test/integration/suite/010-tls/fixtures/issuers.yaml
+++ b/test/integration/suite/010-tls/fixtures/issuers.yaml
@@ -1,0 +1,47 @@
+# Suite-local cert-manager issuers. selfsigned-issuer bootstraps the CA;
+# suite-ca-issuer signs both gnmi-gen's server cert and Cluster client/API certs.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: suite-ca
+spec:
+  isCA: true
+  commonName: suite-ca
+  secretName: suite-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: suite-ca-issuer
+spec:
+  ca:
+    secretName: suite-ca-secret
+---
+# Second CA used only as a negative trust bundle for 010-4.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wrong-ca
+spec:
+  isCA: true
+  commonName: wrong-ca
+  secretName: wrong-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer

--- a/test/integration/suite/010-tls/fixtures/profile.yaml
+++ b/test/integration/suite/010-tls/fixtures/profile.yaml
@@ -1,0 +1,14 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: TargetProfile
+metadata:
+  name: {{ .Name }}
+spec:
+  credentialsRef: sim-credentials
+  encoding: JSON_IETF
+  timeout: 10s
+  retryTimer: 2s
+{{- if .TLS }}
+  # Empty object enables TLS with skip-verify unless Cluster.clientTLS.bundleRef
+  # supplies a CA (there is no skipVerify field on TargetProfile).
+  tls: {}
+{{- end }}

--- a/test/integration/suite/010-tls/fixtures/target.yaml
+++ b/test/integration/suite/010-tls/fixtures/target.yaml
@@ -1,0 +1,12 @@
+apiVersion: operator.gnmic.dev/v1alpha1
+kind: Target
+metadata:
+  name: {{ .Name }}
+  labels:
+    suite: "010"
+{{- if .Role }}
+    role: {{ .Role }}
+{{- end }}
+spec:
+  address: {{ .GnmiGenHost }}:{{ .Port }}
+  profile: {{ .Profile }}

--- a/test/integration/suite/010-tls/gnmi-gen.yaml
+++ b/test/integration/suite/010-tls/gnmi-gen.yaml
@@ -1,0 +1,63 @@
+global:
+  seed: 42
+  shutdown_timeout: 5s
+
+api:
+  listen: 0.0.0.0:8080
+
+data_profiles:
+  interface_counter:
+    type: uint64
+    update_frequency: 1s
+    random:
+      distribution: counter
+      min: 100000
+      max: 900000
+      step_min: 100
+      step_max: 10000
+
+  system_name:
+    type: string
+    update_frequency: 10s
+    random:
+      value: leaf-{{.index}}
+
+# Plaintext gNMI listeners — used to prove a TLS profile is not ignored.
+servers:
+  - name: leaf{{.index}}
+    expand:
+      index:
+        start: 1
+        end: 2
+      listen:
+        host: 0.0.0.0
+        port_start: 57400
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name
+
+  # TLS listeners signed by the suite CA (mounted at /tls).
+  - name: leaf-tls{{.index}}
+    expand:
+      index:
+        start: 1
+        end: 2
+      listen:
+        host: 0.0.0.0
+        port_start: 57410
+    tls:
+      cert_file: /tls/tls.crt
+      key_file: /tls/tls.key
+    authentication:
+      username: gnmic
+      password: gnmic
+    paths:
+      - path: /interface/statistics/in-octets
+        profile: interface_counter
+      - path: /system/name
+        profile: system_name

--- a/test/integration/suite/010-tls/tls_test.go
+++ b/test/integration/suite/010-tls/tls_test.go
@@ -1,0 +1,639 @@
+//go:build integration
+
+// Package tls010 covers Cluster clientTLS / api.tls certificate issuance and
+// TargetProfile TLS collection against mixed plaintext and TLS gnmi-gen targets.
+//
+// Test -> ID:
+//
+//	TestTLS001_ClientCertsMounted          -> 010-1
+//	TestTLS002_MissingIssuerGatesReady     -> 010-2
+//	TestTLS003_SkipVerifyCollectsTLS       -> 010-3
+//	TestTLS004_CAVerification              -> 010-4
+//	TestTLS005_APITLSKeepsConfigPath      -> 010-5
+//	TestTLS006_ClientCertRotation          -> 010-6
+//
+// Run:
+//
+//	make integration-test-010-tls
+package tls010
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gnmicv1alpha1 "github.com/gnmic/operator/api/v1alpha1"
+	"github.com/gnmic/operator/test/integration/harness"
+)
+
+// Paths the operator mounts for Cluster.spec.clientTLS (mirrors internal/gnmic/tls.go).
+const (
+	clientTLSCertPath = "/etc/gnmic/client-tls/tls.crt"
+	clientTLSKeyPath  = "/etc/gnmic/client-tls/tls.key"
+)
+
+var s *harness.Suite
+
+const (
+	cluster = "c1"
+	issuer  = "suite-ca-issuer"
+
+	leaf1    = "leaf1"
+	leaf2    = "leaf2"
+	leafTLS1 = "leaf-tls1"
+	leafTLS2 = "leaf-tls2"
+
+	portPlain1 = 57400
+	portPlain2 = 57401
+	portTLS1   = 57410
+	portTLS2   = 57411
+
+	caBundleName    = "target-ca-bundle"
+	wrongBundleName = "wrong-ca-bundle"
+	serverTLSSecret = "gnmi-gen-server-tls"
+)
+
+var allSimTargets = []string{leaf1, leaf2, leafTLS1, leafTLS2}
+
+func TestMain(m *testing.M) {
+	os.Exit(harness.RunSuite(m, harness.Options{
+		Name:           "010-tls",
+		RequireTargets: allSimTargets,
+		Baseline:       []string{"fixtures/baseline.yaml"},
+		BeforeGnmiGen:  stageCerts,
+	}, &s))
+}
+
+// stageCerts creates the suite CA, signs a server cert for gnmi-gen, and publishes
+// trust bundles the Cluster can mount via clientTLS.bundleRef.
+func stageCerts(suite *harness.Suite) error {
+	b, err := os.ReadFile("fixtures/issuers.yaml")
+	if err != nil {
+		return err
+	}
+	if _, err := suite.K8s.ApplyYAMLNoCleanup(string(b), nil); err != nil {
+		return fmt.Errorf("applying issuers: %w", err)
+	}
+	if err := waitCertificateReady(suite, "suite-ca"); err != nil {
+		return err
+	}
+	if err := waitCertificateReady(suite, "wrong-ca"); err != nil {
+		return err
+	}
+
+	sb, err := os.ReadFile("fixtures/gnmi-gen-server-cert.yaml")
+	if err != nil {
+		return err
+	}
+	if _, err := suite.K8s.ApplyYAMLNoCleanup(string(sb), nil); err != nil {
+		return fmt.Errorf("applying gnmi-gen server cert: %w", err)
+	}
+	if err := waitCertificateReady(suite, "gnmi-gen-server"); err != nil {
+		return err
+	}
+
+	if err := publishCABundle(suite, "suite-ca-secret", caBundleName); err != nil {
+		return err
+	}
+	if err := publishCABundle(suite, "wrong-ca-secret", wrongBundleName); err != nil {
+		return err
+	}
+
+	suite.GnmiGenTLSSecret = serverTLSSecret
+	return nil
+}
+
+func waitCertificateReady(suite *harness.Suite, name string) error {
+	deadline := time.Now().Add(harness.Long)
+	for {
+		var cert certmanagerv1.Certificate
+		err := suite.K8s.Client.Get(suite.Ctx, types.NamespacedName{
+			Namespace: suite.Namespace, Name: name,
+		}, &cert)
+		if err == nil {
+			for _, c := range cert.Status.Conditions {
+				if c.Type == certmanagerv1.CertificateConditionReady && c.Status == cmmeta.ConditionTrue {
+					return nil
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("certificate %s not Ready: %v", name, err)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func publishCABundle(suite *harness.Suite, secretName, cmName string) error {
+	var sec corev1.Secret
+	if err := suite.K8s.Client.Get(suite.Ctx, types.NamespacedName{
+		Namespace: suite.Namespace, Name: secretName,
+	}, &sec); err != nil {
+		return fmt.Errorf("reading CA secret %s: %w", secretName, err)
+	}
+	pem := sec.Data["ca.crt"]
+	if len(pem) == 0 {
+		pem = sec.Data["tls.crt"]
+	}
+	if len(pem) == 0 {
+		return fmt.Errorf("CA secret %s has neither ca.crt nor tls.crt", secretName)
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: suite.Namespace},
+		Data:       map[string]string{"ca.crt": string(pem)},
+	}
+	cm.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+	return suite.K8s.ApplyNoCleanup(cm)
+}
+
+func waitClusterReady(t *testing.T, name string) {
+	t.Helper()
+	harness.WaitClusterReady(t, s.K8s, name)
+	s.K8s.WaitReadyPods(t, name, 1, harness.Long)
+}
+
+// waitPodFile blocks until path exists and is non-empty in a ready collector pod.
+// Used after clientTLS / api.tls patches: Cluster Ready can stay True on the old
+// pod while the STS rolls to pick up new volume mounts.
+func waitPodFile(t *testing.T, clusterName, path string) {
+	t.Helper()
+	harness.Wait(t, harness.Long, fmt.Sprintf("pod file %s", path), func() (bool, string) {
+		pods := s.K8s.ClusterPods(t, clusterName)
+		for i := range pods {
+			p := &pods[i]
+			ready := false
+			for _, c := range p.Status.Conditions {
+				if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+					ready = true
+					break
+				}
+			}
+			if !ready {
+				continue
+			}
+			out, err := s.K8s.ExecQuiet(p.Name, harness.CollectorContainer, "sh", "-c",
+				fmt.Sprintf("test -s %q && echo ok || echo missing", path))
+			if err != nil {
+				return false, err.Error()
+			}
+			if strings.Contains(out, "ok") {
+				return true, ""
+			}
+			return false, out
+		}
+		return false, "no ready pods"
+	})
+}
+
+func patchClientTLS(t *testing.T, issuerRef, bundleRef string) {
+	t.Helper()
+	patch := fmt.Sprintf(`{"spec":{"clientTLS":{"issuerRef":%q`, issuerRef)
+	if bundleRef != "" {
+		patch += fmt.Sprintf(`,"bundleRef":%q`, bundleRef)
+	}
+	patch += `}}}`
+	s.K8s.Patch(t, s.K8s.Cluster(t, cluster), patch)
+	waitCertReady(t, harness.ClientCertName(cluster))
+	waitClusterReady(t, cluster)
+	waitPodFile(t, cluster, clientTLSCertPath)
+	if bundleRef != "" {
+		waitPodFile(t, cluster, "/etc/gnmic/client-ca/ca.crt")
+	}
+	harness.WaitConfigApplied(t, s.K8s, cluster)
+}
+
+func patchAPITLS(t *testing.T, issuerRef string) {
+	t.Helper()
+	s.K8s.Patch(t, s.K8s.Cluster(t, cluster), fmt.Sprintf(
+		`{"spec":{"api":{"restPort":7890,"tls":{"issuerRef":%q}}}}`, issuerRef))
+	waitCertReady(t, harness.APICertName(cluster, 0))
+	harness.WaitClusterCondition(t, s.K8s, cluster, harness.CondCertificatesReady, metav1.ConditionTrue, harness.Long)
+	waitClusterReady(t, cluster)
+	waitPodFile(t, cluster, "/etc/gnmic/tls/tls.crt")
+	harness.WaitConfigApplied(t, s.K8s, cluster)
+}
+
+func waitIdle(t *testing.T) {
+	t.Helper()
+	var targets gnmicv1alpha1.TargetList
+	if err := s.K8s.Client.List(s.Ctx, &targets, client.InNamespace(s.Namespace)); err == nil {
+		for i := range targets.Items {
+			_ = s.K8s.Client.Delete(s.Ctx, &targets.Items[i])
+		}
+	}
+	var profiles gnmicv1alpha1.TargetProfileList
+	if err := s.K8s.Client.List(s.Ctx, &profiles, client.InNamespace(s.Namespace)); err == nil {
+		for i := range profiles.Items {
+			_ = s.K8s.Client.Delete(s.Ctx, &profiles.Items[i])
+		}
+	}
+	// Drop extra clusters created by 010-1 / 010-2; keep baseline c1.
+	var clusters gnmicv1alpha1.ClusterList
+	if err := s.K8s.Client.List(s.Ctx, &clusters, client.InNamespace(s.Namespace)); err == nil {
+		for i := range clusters.Items {
+			if clusters.Items[i].Name == cluster {
+				continue
+			}
+			_ = s.K8s.Client.Delete(s.Ctx, &clusters.Items[i])
+		}
+	}
+	harness.Wait(t, harness.Medium, "extra clusters gone", func() (bool, string) {
+		var left gnmicv1alpha1.ClusterList
+		if err := s.K8s.Client.List(s.Ctx, &left, client.InNamespace(s.Namespace)); err != nil {
+			return false, err.Error()
+		}
+		n := 0
+		for _, c := range left.Items {
+			if c.Name != cluster {
+				n++
+			}
+		}
+		return n == 0, fmt.Sprintf("%d extra", n)
+	})
+	harness.Wait(t, harness.Medium, "targets gone", func() (bool, string) {
+		var left gnmicv1alpha1.TargetList
+		if err := s.K8s.Client.List(s.Ctx, &left, client.InNamespace(s.Namespace)); err != nil {
+			return false, err.Error()
+		}
+		return len(left.Items) == 0, fmt.Sprintf("%d remain", len(left.Items))
+	})
+	harness.Wait(t, harness.Medium, "simulators idle", func() (bool, string) {
+		for _, name := range allSimTargets {
+			if n := s.GnmiGen.StreamCount(name); n != 0 {
+				return false, fmt.Sprintf("%s=%d", name, n)
+			}
+		}
+		return true, ""
+	})
+	// Reset c1 TLS knobs so later tests start from a known plaintext API.
+	resetClusterTLS(t)
+}
+
+func resetClusterTLS(t *testing.T) {
+	t.Helper()
+	c := s.K8s.Cluster(t, cluster)
+	if c.Spec.ClientTLS == nil && (c.Spec.API == nil || c.Spec.API.TLS == nil) {
+		waitClusterReady(t, cluster)
+		return
+	}
+	s.K8s.Patch(t, c, `{"spec":{"clientTLS":null,"api":{"restPort":7890,"tls":null}}}`)
+	harness.Wait(t, harness.Long, "c1 TLS cleared", func() (bool, string) {
+		var cur gnmicv1alpha1.Cluster
+		if err := s.K8s.Client.Get(s.Ctx, types.NamespacedName{Namespace: s.Namespace, Name: cluster}, &cur); err != nil {
+			return false, err.Error()
+		}
+		if cur.Spec.ClientTLS != nil {
+			return false, "clientTLS still set"
+		}
+		if cur.Spec.API != nil && cur.Spec.API.TLS != nil {
+			return false, "api.tls still set"
+		}
+		return true, ""
+	})
+	waitClusterReady(t, cluster)
+	// Ensure the rolled pod no longer has API TLS material mounted.
+	harness.Wait(t, harness.Long, "api TLS unmounted", func() (bool, string) {
+		pods := s.K8s.ClusterPods(t, cluster)
+		for i := range pods {
+			p := &pods[i]
+			ready := false
+			for _, c := range p.Status.Conditions {
+				if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+					ready = true
+					break
+				}
+			}
+			if !ready {
+				continue
+			}
+			out, err := s.K8s.ExecQuiet(p.Name, harness.CollectorContainer, "sh", "-c",
+				`test -e /etc/gnmic/tls/tls.crt && echo present || echo absent`)
+			if err != nil {
+				return false, err.Error()
+			}
+			return strings.Contains(out, "absent"), out
+		}
+		return false, "no ready pods"
+	})
+	harness.WaitConfigApplied(t, s.K8s, cluster)
+}
+
+func applyProfile(t *testing.T, name string, tls bool) {
+	t.Helper()
+	s.K8s.ApplyFile(t, "fixtures/profile.yaml", map[string]any{
+		"Name": name,
+		"TLS":  tls,
+	})
+}
+
+func applyTarget(t *testing.T, name string, port int, profile, role string) {
+	t.Helper()
+	s.K8s.ApplyFile(t, "fixtures/target.yaml", map[string]any{
+		"Name":    name,
+		"Port":    port,
+		"Profile": profile,
+		"Role":    role,
+	})
+}
+
+func applyCluster(t *testing.T, name string, vars map[string]any) {
+	t.Helper()
+	base := map[string]any{
+		"Name":         name,
+		"Replicas":     1,
+		"RestPort":     7890,
+		"APIIssuer":    "",
+		"ClientIssuer": "",
+		"BundleRef":    "",
+	}
+	for k, v := range vars {
+		base[k] = v
+	}
+	s.K8s.ApplyFile(t, "fixtures/cluster.yaml", base)
+}
+
+func waitCertReady(t *testing.T, name string) *certmanagerv1.Certificate {
+	t.Helper()
+	var cert certmanagerv1.Certificate
+	harness.Wait(t, harness.Long, fmt.Sprintf("Certificate %s Ready", name), func() (bool, string) {
+		err := s.K8s.Client.Get(s.Ctx, types.NamespacedName{Namespace: s.Namespace, Name: name}, &cert)
+		if err != nil {
+			return false, err.Error()
+		}
+		for _, c := range cert.Status.Conditions {
+			if c.Type == certmanagerv1.CertificateConditionReady && c.Status == cmmeta.ConditionTrue {
+				return true, ""
+			}
+		}
+		return false, "not ready"
+	})
+	return &cert
+}
+
+func targetNotReady(t *testing.T, name string) {
+	t.Helper()
+	harness.Wait(t, harness.Medium, name+" not READY", func() (bool, string) {
+		tgt, err := s.K8s.TargetQuiet(name)
+		if err != nil {
+			return false, err.Error()
+		}
+		if tgt.Status.State == "READY" {
+			return false, "reached READY"
+		}
+		cs := tgt.Status.ClusterStates[cluster]
+		if cs.State == "" && cs.ConnectionState == "" {
+			return false, "no cluster state yet"
+		}
+		return cs.State != "running" || cs.ConnectionState != "READY",
+			fmt.Sprintf("state=%q connection=%q reason=%q", cs.State, cs.ConnectionState, cs.FailedReason)
+	})
+}
+
+// 010-1: clientTLS produces a cert-manager Certificate, Secret, and mount.
+func TestTLS001_ClientCertsMounted(t *testing.T) {
+	waitIdle(t)
+	const name = "clienttls"
+	applyCluster(t, name, map[string]any{"ClientIssuer": issuer})
+	waitClusterReady(t, name)
+
+	certName := harness.ClientCertName(name)
+	cert := waitCertReady(t, certName)
+	harness.AssertOwnedBy(t, cert, "Cluster", name)
+
+	var sec corev1.Secret
+	s.K8s.WaitExists(t, certName, &sec)
+	if len(sec.Data["tls.crt"]) == 0 || len(sec.Data["tls.key"]) == 0 {
+		t.Fatalf("client TLS secret missing tls.crt/tls.key keys: %v", keysOf(sec.Data))
+	}
+
+	pod := harness.PodName(name, 0)
+	crt := s.K8s.Exec(t, pod, harness.CollectorContainer, "sh", "-c",
+		fmt.Sprintf("test -s %s && wc -c <%s", clientTLSCertPath, clientTLSCertPath))
+	key := s.K8s.Exec(t, pod, harness.CollectorContainer, "sh", "-c",
+		fmt.Sprintf("test -s %s && wc -c <%s", clientTLSKeyPath, clientTLSKeyPath))
+	if crt == "" || key == "" {
+		t.Fatalf("client TLS files not readable in pod: crt=%q key=%q", crt, key)
+	}
+
+	// CertificatesReady is only published for api.tls today; clientTLS gates
+	// reconcile by requeue instead. Ready on the Cluster is the readiness signal.
+	c := s.K8s.Cluster(t, name)
+	if !conditionTrue(c, harness.CondReady) {
+		t.Fatal("Cluster Ready is not True after clientTLS issuance")
+	}
+}
+
+// 010-2: a missing issuer keeps the Cluster from becoming Ready until fixed.
+func TestTLS002_MissingIssuerGatesReady(t *testing.T) {
+	waitIdle(t)
+	const name = "badissuer"
+	applyCluster(t, name, map[string]any{"ClientIssuer": "does-not-exist"})
+
+	certName := harness.ClientCertName(name)
+	harness.Wait(t, harness.Medium, "Certificate exists but not Ready", func() (bool, string) {
+		var cert certmanagerv1.Certificate
+		err := s.K8s.Client.Get(s.Ctx, types.NamespacedName{Namespace: s.Namespace, Name: certName}, &cert)
+		if err != nil {
+			return false, err.Error()
+		}
+		for _, c := range cert.Status.Conditions {
+			if c.Type == certmanagerv1.CertificateConditionReady && c.Status == cmmeta.ConditionTrue {
+				return false, "unexpectedly Ready"
+			}
+		}
+		return true, "not ready yet"
+	})
+
+	harness.Consistently(t, 5*time.Second, time.Second, "Cluster stays not Ready", func() (bool, string) {
+		var c gnmicv1alpha1.Cluster
+		if err := s.K8s.Client.Get(s.Ctx, types.NamespacedName{Namespace: s.Namespace, Name: name}, &c); err != nil {
+			return false, err.Error()
+		}
+		if conditionTrue(&c, harness.CondReady) {
+			return false, "Ready became True"
+		}
+		return true, ""
+	})
+	for _, sim := range allSimTargets {
+		if n := s.GnmiGen.StreamCount(sim); n != 0 {
+			t.Fatalf("expected no collection while certs blocked, %s has %d streams", sim, n)
+		}
+	}
+
+	// Creating the missing issuer as an alias of the suite CA lets cert-manager
+	// issue the cert; the Cluster should converge without further edits.
+	alias := []byte(fmt.Sprintf(`
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: does-not-exist
+spec:
+  ca:
+    secretName: suite-ca-secret
+`))
+	if _, err := s.K8s.ApplyYAMLNoCleanup(string(alias), nil); err != nil {
+		t.Fatalf("creating alias issuer: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.K8s.Client.Delete(s.Ctx, &certmanagerv1.Issuer{
+			ObjectMeta: metav1.ObjectMeta{Name: "does-not-exist", Namespace: s.Namespace},
+		})
+	})
+
+	waitCertReady(t, certName)
+	waitClusterReady(t, name)
+}
+
+// 010-3: TargetProfile tls:{} collects TLS targets; same profile fails on plaintext.
+func TestTLS003_SkipVerifyCollectsTLS(t *testing.T) {
+	waitIdle(t)
+	applyProfile(t, "skip-verify", true)
+	applyTarget(t, leafTLS1, portTLS1, "skip-verify", "tls")
+	applyTarget(t, leafTLS2, portTLS2, "skip-verify", "tls")
+	applyTarget(t, "plain-mismatch", portPlain1, "skip-verify", "plain")
+
+	s.GnmiGen.WaitStreams(t, leafTLS1, 1)
+	s.GnmiGen.WaitStreams(t, leafTLS2, 1)
+	harness.WaitTargetState(t, s.K8s, leafTLS1, "READY")
+	harness.WaitTargetState(t, s.K8s, leafTLS2, "READY")
+
+	targetNotReady(t, "plain-mismatch")
+	s.GnmiGen.WaitStreams(t, leaf1, 0)
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 10*time.Second, 1, leafTLS1, leafTLS2)
+}
+
+// 010-4: clientTLS.bundleRef verifies the suite CA and rejects an unrelated CA.
+func TestTLS004_CAVerification(t *testing.T) {
+	waitIdle(t)
+
+	patchClientTLS(t, issuer, caBundleName)
+
+	// With clientTLS set, targets get TLS even without profile.tls.
+	applyProfile(t, "ca-ok", false)
+	applyTarget(t, leafTLS1, portTLS1, "ca-ok", "tls")
+	s.GnmiGen.WaitStreams(t, leafTLS1, 1)
+	harness.WaitTargetState(t, s.K8s, leafTLS1, "READY")
+
+	// Flip to the wrong CA; verification must fail without silent downgrade.
+	// bundleRef change updates the ConfigMap volume name → pod rollout.
+	patchClientTLS(t, issuer, wrongBundleName)
+
+	applyTarget(t, leafTLS2, portTLS2, "ca-ok", "tls")
+	targetNotReady(t, leafTLS2)
+	harness.Wait(t, harness.Medium, "leaf-tls2 has no stream", func() (bool, string) {
+		n := s.GnmiGen.StreamCount(leafTLS2)
+		return n == 0, fmt.Sprintf("streams=%d", n)
+	})
+	// leaf-tls1 may flap while the plan re-applies; it must not stay collected
+	// against a CA that cannot verify the server cert.
+	harness.Wait(t, harness.Medium, "leaf-tls1 loses stream under wrong CA", func() (bool, string) {
+		n := s.GnmiGen.StreamCount(leafTLS1)
+		return n == 0, fmt.Sprintf("streams=%d", n)
+	})
+}
+
+// 010-5: enabling api.tls must not break the operator's apply path.
+func TestTLS005_APITLSKeepsConfigPath(t *testing.T) {
+	waitIdle(t)
+	applyProfile(t, "skip-verify", true)
+	applyTarget(t, leafTLS1, portTLS1, "skip-verify", "tls")
+	s.GnmiGen.WaitStreams(t, leafTLS1, 1)
+	harness.WaitTargetState(t, s.K8s, leafTLS1, "READY")
+
+	patchAPITLS(t, issuer)
+
+	// A live subscription edit must still reach the wire through the TLS API.
+	sub := &gnmicv1alpha1.Subscription{}
+	s.K8s.WaitExists(t, "if-counters", sub)
+	s.K8s.Patch(t, sub, `{"spec":{"sampleInterval":"2s"}}`)
+	harness.WaitConfigApplied(t, s.K8s, cluster)
+
+	s.GnmiGen.WaitStreams(t, leafTLS1, 1)
+	s.GnmiGen.WaitNotificationsAdvance(t, leafTLS1)
+	harness.WaitTargetState(t, s.K8s, leafTLS1, "READY")
+	s.GnmiGen.ConsistentlyCollectedOnce(t, 10*time.Second, 1, leafTLS1)
+}
+
+// 010-6: deleting the clientTLS Secret forces reissue without lasting outage.
+func TestTLS006_ClientCertRotation(t *testing.T) {
+	waitIdle(t)
+
+	patchClientTLS(t, issuer, "")
+	certName := harness.ClientCertName(cluster)
+
+	applyProfile(t, "skip-verify", true)
+	applyTarget(t, leafTLS1, portTLS1, "skip-verify", "tls")
+	applyTarget(t, leafTLS2, portTLS2, "skip-verify", "tls")
+	s.GnmiGen.AssertCollectedOnce(t, 1, leafTLS1, leafTLS2)
+
+	var before corev1.Secret
+	s.K8s.WaitExists(t, certName, &before)
+	beforeRV := before.ResourceVersion
+	if err := s.K8s.Client.Delete(s.Ctx, &before); err != nil {
+		t.Fatalf("deleting client TLS secret: %v", err)
+	}
+
+	zeroSince := map[string]time.Time{}
+	deadline := time.Now().Add(harness.Long)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for clientTLS secret reissue + recovery")
+		}
+		for _, name := range []string{leafTLS1, leafTLS2} {
+			n := s.GnmiGen.StreamCount(name)
+			if n > 1 {
+				t.Fatalf("%s has %d streams during rotation", name, n)
+			}
+			if n == 0 {
+				if zeroSince[name].IsZero() {
+					zeroSince[name] = time.Now()
+				} else if time.Since(zeroSince[name]) > 60*time.Second {
+					t.Fatalf("%s at zero streams for >60s during rotation", name)
+				}
+			} else {
+				delete(zeroSince, name)
+			}
+		}
+
+		var sec corev1.Secret
+		err := s.K8s.Client.Get(s.Ctx, types.NamespacedName{Namespace: s.Namespace, Name: certName}, &sec)
+		if err == nil && sec.ResourceVersion != beforeRV && len(sec.Data["tls.crt"]) > 0 {
+			if s.GnmiGen.StreamCount(leafTLS1) == 1 && s.GnmiGen.StreamCount(leafTLS2) == 1 {
+				break
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	waitCertReady(t, certName)
+	s.GnmiGen.AssertCollectedOnce(t, 1, leafTLS1, leafTLS2)
+	pod := harness.PodName(cluster, 0)
+	_ = s.K8s.Exec(t, pod, harness.CollectorContainer, "sh", "-c",
+		fmt.Sprintf("test -s %s", clientTLSCertPath))
+}
+
+func conditionTrue(c *gnmicv1alpha1.Cluster, typ string) bool {
+	for _, cond := range c.Status.Conditions {
+		if cond.Type == typ {
+			return cond.Status == metav1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func keysOf(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/test/integration/suite/013-scale/scale_test.go
+++ b/test/integration/suite/013-scale/scale_test.go
@@ -148,15 +148,20 @@ spec:
 
 func waitFleetReady(t *testing.T) time.Duration {
 	t.Helper()
+	return waitFleetReadyWithin(t, harness.Long)
+}
+
+func waitFleetReadyWithin(t *testing.T, timeout time.Duration) time.Duration {
+	t.Helper()
 	restoreFleetAddresses(t)
 	start := time.Now()
-	s.K8s.WaitReadyPods(t, cluster, replicas, harness.Long)
+	s.K8s.WaitReadyPods(t, cluster, replicas, timeout)
 	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
 		TargetsCount:      harness.I32(int32(fleetN)),
 		UnassignedTargets: harness.I32(0),
 		ReadyReplicas:     harness.I32(int32(replicas)),
 	})
-	s.GnmiGen.WaitFleetStreams(t, harness.Long, 1, targets)
+	s.GnmiGen.WaitFleetStreams(t, timeout, 1, targets)
 	s.GnmiGen.WaitStreams(t, spareSim, 0)
 	elapsed := time.Since(start)
 	t.Logf("fleet converged in %s (SCALE_TARGETS=%d SCALE_REPLICAS=%d)", elapsed, fleetN, replicas)
@@ -186,14 +191,67 @@ func assertSuiteResourceUsage(t *testing.T) {
 	if len(gens) == 0 {
 		t.Fatal("no gnmi-gen pods")
 	}
+	genUsages := s.K8s.PodUsagesOf(t, gens)
 	for _, p := range gens {
-		harness.AssertPodUsageWithinLimits(t, p, s.K8s.PodUsageOf(t, p))
+		u := genUsages[p.Name]
+		harness.LogPodUsage(t, u)
+		harness.AssertPodUsageWithinLimitsQuiet(t, p, u)
 	}
-	for _, p := range s.K8s.ClusterPods(t, cluster) {
-		harness.AssertPodUsageWithinLimits(t, p, s.K8s.PodUsageOf(t, p))
+
+	collectors := s.K8s.ClusterPods(t, cluster)
+	colUsages := s.K8s.PodUsagesOf(t, collectors)
+	var maxCPU, sumCPU float64
+	var maxMem, sumMem uint64
+	var maxCPUName, maxMemName string
+	for _, p := range collectors {
+		u := colUsages[p.Name]
+		harness.AssertPodUsageWithinLimitsQuiet(t, p, u)
+		sumCPU += u.CPUCores
+		sumMem += u.MemoryBytes
+		if u.CPUCores >= maxCPU {
+			maxCPU, maxCPUName = u.CPUCores, p.Name
+		}
+		if u.MemoryBytes >= maxMem {
+			maxMem, maxMemName = u.MemoryBytes, p.Name
+		}
 	}
-	for _, p := range s.K8s.OperatorPods(t) {
-		harness.AssertPodUsageWithinLimits(t, p, s.K8s.PodUsageOf(t, p))
+	n := float64(len(collectors))
+	if n == 0 {
+		t.Fatal("no collector pods")
+	}
+	t.Logf("usage collectors: n=%d cpu[avg=%.3f max=%.3f %s] cores mem[avg=%.1f max=%.1f %s] MiB",
+		len(collectors), sumCPU/n, maxCPU, maxCPUName,
+		float64(sumMem)/(n*1024*1024), float64(maxMem)/(1024*1024), maxMemName)
+
+	ops := s.K8s.OperatorPods(t)
+	opUsages := s.K8s.PodUsagesOf(t, ops)
+	for _, p := range ops {
+		u := opUsages[p.Name]
+		harness.LogPodUsage(t, u)
+		harness.AssertPodUsageWithinLimitsQuiet(t, p, u)
+	}
+}
+
+// assertOperatorMemStable fails if working-set grew more than maxGrowthBytes
+// across a sample window (leak / runaway cache growth smoke check).
+func assertOperatorMemStable(t *testing.T, windows []harness.UsageWindow, maxGrowthBytes uint64) {
+	t.Helper()
+	for _, w := range windows {
+		if w.Samples < 2 {
+			t.Fatalf("%s: need ≥2 samples for stability, got %d", w.Name, w.Samples)
+		}
+		if w.MemMax < w.MemMin {
+			continue
+		}
+		growth := w.MemMax - w.MemMin
+		if growth > maxGrowthBytes {
+			t.Fatalf("%s memory grew %.1f MiB over soak (min=%.1f max=%.1f; allow ≤%.1f MiB)",
+				w.Name,
+				float64(growth)/(1024*1024),
+				float64(w.MemMin)/(1024*1024),
+				float64(w.MemMax)/(1024*1024),
+				float64(maxGrowthBytes)/(1024*1024))
+		}
 	}
 }
 
@@ -230,13 +288,29 @@ func establishedSnapshot() map[string]time.Time {
 }
 
 func TestScale001_FleetConverges(t *testing.T) {
-	elapsed := waitFleetReady(t)
-	harness.WaitClusterCondition(t, s.K8s, cluster, harness.CondReady, metav1.ConditionTrue, harness.Long)
+	const timeout = 10 * time.Minute
+	// Sample through converge so peak CPU is visible, not only the idle
+	// post-Ready reading that AssertPodUsageWithinLimits would see.
+	opSampler := s.K8s.StartOperatorUsageSampler(2 * time.Second)
+	elapsed := waitFleetReadyWithin(t, timeout)
+	harness.WaitClusterCondition(t, s.K8s, cluster, harness.CondReady, metav1.ConditionTrue, timeout)
 
 	promSvc := harness.PromServiceName(cluster, pipeline, output)
 	s.K8s.WaitExists(t, promSvc, &corev1.Service{})
-	s.K8s.WaitClusterPrometheusSources(t, cluster, pipeline, output, targets, harness.Long)
+	s.K8s.WaitClusterPrometheusSources(t, cluster, pipeline, output, targets, timeout)
+	convergeWindows := opSampler.StopAndLog(t, "converge")
+	for _, p := range s.K8s.OperatorPods(t) {
+		for _, w := range convergeWindows {
+			if w.Name == p.Name {
+				harness.AssertUsageWindowWithinLimits(t, p, w)
+			}
+		}
+	}
+
 	assertSuiteResourceUsage(t)
+	// Short soak: steady-state memory should not climb after Ready.
+	soak := s.K8s.SampleOperatorUsageFor(t, 30*time.Second, 2*time.Second, "post-converge soak")
+	assertOperatorMemStable(t, soak, 32*1024*1024)
 	t.Logf("013-1 converge_seconds=%.1f scale_targets=%d", elapsed.Seconds(), fleetN)
 }
 
@@ -323,6 +397,7 @@ func TestScale003_SingleTargetChangeIsCheap(t *testing.T) {
 
 func TestScale004_ChurnKeepsInvariant(t *testing.T) {
 	waitFleetReady(t)
+	opSampler := s.K8s.StartOperatorUsageSampler(2 * time.Second)
 
 	var overHits atomic.Int32
 	stop := make(chan struct{})
@@ -376,12 +451,22 @@ spec:
 		if _, err := s.K8s.ApplyYAMLNoCleanup(b.String(), nil); err != nil {
 			close(stop)
 			wg.Wait()
+			_ = opSampler.Stop()
 			t.Fatalf("recreating targets: %v", err)
 		}
 		time.Sleep(5 * time.Second)
 	}
 	close(stop)
 	wg.Wait()
+
+	windows := opSampler.StopAndLog(t, "target churn")
+	for _, p := range s.K8s.OperatorPods(t) {
+		for _, w := range windows {
+			if w.Name == p.Name {
+				harness.AssertUsageWindowWithinLimits(t, p, w)
+			}
+		}
+	}
 
 	if overHits.Load() > 0 {
 		t.Fatalf("observed %d samples with >1 stream during churn", overHits.Load())
@@ -406,6 +491,7 @@ spec:
 func TestScale005_ChaosRebootsRecover(t *testing.T) {
 	waitFleetReady(t)
 	restartsBefore := s.K8s.RestartCounts(t, cluster)
+	opSampler := s.K8s.StartOperatorUsageSampler(2 * time.Second)
 
 	var overHits atomic.Int32
 	stop := make(chan struct{})
@@ -452,6 +538,7 @@ func TestScale005_ChaosRebootsRecover(t *testing.T) {
 	// Design: within 2 minutes of the last reboot (targets already up above).
 	s.GnmiGen.WaitFleetStreams(t, harness.Medium, 1, targets)
 	if overHits.Load() > 0 {
+		_ = opSampler.Stop()
 		t.Fatalf("observed %d samples with >1 stream during/after chaos", overHits.Load())
 	}
 	harness.WaitClusterCounts(t, s.K8s, cluster, harness.ClusterCounts{
@@ -467,5 +554,14 @@ func TestScale005_ChaosRebootsRecover(t *testing.T) {
 	harness.WaitTargetsReady(t, s.K8s, readyTimeout, targets)
 	harness.AssertNoRestarts(t, restartsBefore, s.K8s.RestartCounts(t, cluster))
 	harness.AssertNoPanics(t, s.K8s.OperatorLogs(t, 15*time.Minute))
+
+	windows := opSampler.StopAndLog(t, "chaos reboots")
+	for _, p := range s.K8s.OperatorPods(t) {
+		for _, w := range windows {
+			if w.Name == p.Name {
+				harness.AssertUsageWindowWithinLimits(t, p, w)
+			}
+		}
+	}
 	assertSuiteResourceUsage(t)
 }


### PR DESCRIPTION
- Updated subscription keying in the cluster reconciler to ensure unique outputs for shared subscriptions across pipelines.
- Improved volume and volume mount management in StatefulSet reconciliation to maintain consistency with TLS configurations.
- Added helper functions to compare volume mounts and environment variables, ensuring proper updates during scaling.
- Refined Prometheus service configuration to prioritize operator-defined labels and annotations.
- Enhanced the `parseListenPortAndPath` function to handle empty configurations more gracefully.
- Updated tests to reflect changes in subscription configuration and ensure proper handling of new parameters.